### PR TITLE
Skip verification if the account is already verified

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -629,95 +629,104 @@ issue() {
     d=$(echo $ventry | cut -d $sep -f 1)
     keyauthorization=$(echo $ventry | cut -d $sep -f 2)
     uri=$(echo $ventry | cut -d $sep -f 3)
-    _info "Verifying:$d"
-    _debug "d" "$d"
-    _debug "keyauthorization" "$keyauthorization"
-    _debug "uri" "$uri"
-    removelevel=""
-    token=""
-    if [ "$vtype" == "$VTYPE_HTTP" ] ; then
-      if [ "$Le_Webroot" == "no" ] ; then
-        _info "Standalone mode server"
-        _startserver "$keyauthorization" &
-        serverproc="$!"
-        sleep 2
-        _debug serverproc $serverproc
-      else
-        if [ -z "$wellknown_path" ] ; then
-          wellknown_path="$Le_Webroot/.well-known/acme-challenge"
-        fi
-        _debug wellknown_path "$wellknown_path"
-        
-        if [ ! -d "$Le_Webroot/.well-known" ] ; then 
-          removelevel='1'
-        elif [ ! -d "$Le_Webroot/.well-known/acme-challenge" ] ; then 
-          removelevel='2'
+
+    # check if domain is already verified for the account
+    _info "Checking if domain is already verified"
+    if ! _get $uri ; then
+      _err "$d:Verify pending"
+
+      _info "Verifying:$d"
+      _debug "d" "$d"
+      _debug "keyauthorization" "$keyauthorization"
+      _debug "uri" "$uri"
+      removelevel=""
+      token=""
+      if [ "$vtype" == "$VTYPE_HTTP" ] ; then
+        if [ "$Le_Webroot" == "no" ] ; then
+          _info "Standalone mode server"
+          _startserver "$keyauthorization" &
+          serverproc="$!"
+          sleep 2
+          _debug serverproc $serverproc
         else
-          removelevel='3'
+          if [ -z "$wellknown_path" ] ; then
+            wellknown_path="$Le_Webroot/.well-known/acme-challenge"
+          fi
+          _debug wellknown_path "$wellknown_path"
+
+          if [ ! -d "$Le_Webroot/.well-known" ] ; then
+            removelevel='1'
+          elif [ ! -d "$Le_Webroot/.well-known/acme-challenge" ] ; then
+            removelevel='2'
+          else
+            removelevel='3'
+          fi
+
+          token="$(echo -e -n "$keyauthorization" | cut -d '.' -f 1)"
+          _debug "writing token:$token to $wellknown_path/$token"
+
+          mkdir -p "$wellknown_path"
+          echo -n "$keyauthorization" > "$wellknown_path/$token"
+
+          webroot_owner=$(stat -c '%U:%G' $Le_Webroot)
+          _debug "Changing owner/group of .well-known to $webroot_owner"
+          chown -R $webroot_owner "$Le_Webroot/.well-known"
+
         fi
-        
-        token="$(echo -e -n "$keyauthorization" | cut -d '.' -f 1)"
-        _debug "writing token:$token to $wellknown_path/$token"
-
-        mkdir -p "$wellknown_path"
-        echo -n "$keyauthorization" > "$wellknown_path/$token"
-
-        webroot_owner=$(stat -c '%U:%G' $Le_Webroot)
-        _debug "Changing owner/group of .well-known to $webroot_owner"
-        chown -R $webroot_owner "$Le_Webroot/.well-known"
-        
       fi
-    fi
-    
-    _send_signed_request $uri "{\"resource\": \"challenge\", \"keyAuthorization\": \"$keyauthorization\"}"
-    
-    if [ ! -z "$code" ] && [ ! "$code" == '202' ] ; then
-      _err "$d:Challenge error: $resource"
-      _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
-      _clearup
-      return 1
-    fi
-    
-    while [ "1" ] ; do
-      _debug "sleep 5 secs to verify"
-      sleep 5
-      _debug "checking"
-      
-      if ! _get $uri ; then
-        _err "$d:Verify error:$resource"
+
+      _send_signed_request $uri "{\"resource\": \"challenge\", \"keyAuthorization\": \"$keyauthorization\"}"
+
+      if [ ! -z "$code" ] && [ ! "$code" == '202' ] ; then
+        _err "$d:Challenge error: $resource"
         _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
         _clearup
         return 1
       fi
-      
-      status=$(echo $response | egrep -o  '"status":"[^"]+"' | cut -d : -f 2 | sed 's/"//g')
-      if [ "$status" == "valid" ] ; then
-        _info "Success"
-        _stopserver $serverproc
-        serverproc=""
-        _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
-        break;
-      fi
-      
-      if [ "$status" == "invalid" ] ; then
-         error=$(echo $response | egrep -o '"error":{[^}]*}' | grep -o '"detail":"[^"]*"' | cut -d '"' -f 4)
-        _err "$d:Verify error:$error"
-        _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
-        _clearup
-        return 1;
-      fi
-      
-      if [ "$status" == "pending" ] ; then
-        _info "Pending"
-      else
-        _err "$d:Verify error:$response" 
-        _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
-        _clearup
-        return 1
-      fi
-      
-    done
-    
+
+      while [ "1" ] ; do
+        _debug "sleep 5 secs to verify"
+        sleep 5
+        _debug "checking"
+
+        if ! _get $uri ; then
+          _err "$d:Verify error:$resource"
+          _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
+          _clearup
+          return 1
+        fi
+
+        status=$(echo $response | egrep -o  '"status":"[^"]+"' | cut -d : -f 2 | sed 's/"//g')
+        if [ "$status" == "valid" ] ; then
+          _info "Success"
+          _stopserver $serverproc
+          serverproc=""
+          _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
+          break;
+        fi
+
+        if [ "$status" == "invalid" ] ; then
+           error=$(echo $response | egrep -o '"error":{[^}]*}' | grep -o '"detail":"[^"]*"' | cut -d '"' -f 4)
+          _err "$d:Verify error:$error"
+          _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
+          _clearup
+          return 1;
+        fi
+
+        if [ "$status" == "pending" ] ; then
+          _info "Pending"
+        else
+          _err "$d:Verify error:$response"
+          _clearupwebbroot "$Le_Webroot" "$removelevel" "$token"
+          _clearup
+          return 1
+        fi
+
+      done
+    else
+      _info "$d:Already verified"
+    fi
+
   done
 
   _clearup


### PR DESCRIPTION
There is no need to make a new-authz call if the account is already verified for the domain.

Skipping it may be quite helpful when using dns.