### PR TITLE
Save ACCOUNT_KEY_PATH and ACCOUNT_EMAIL in _initconf()

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -1651,6 +1651,14 @@ USER_AGENT=\"le.sh client: $PROJECT\"
 #CX_Secret=\"sADDsdasdgdsf\"
 
     " > $ACCOUNT_CONF_PATH
+
+    if [[ -n "$ACCOUNT_KEY_PATH" && "$ACCOUNT_KEY_PATH" != "$LE_WORKING_DIR/account.key" ]]; then
+      _saveaccountconf "ACCOUNT_KEY_PATH" "$ACCOUNT_KEY_PATH"
+    fi
+
+    if [[ -n "ACCOUNT_EMAIL" ]]; then
+      _saveaccountconf "ACCOUNT_EMAIL" "$ACCOUNT_EMAIL"
+    fi
   fi
 }
 


### PR DESCRIPTION
this enables the following one liner for initial configuration at install time, which would mean that most users would never need to touch their account.conf manually:

ACCOUNT_KEY_PATH=/path/to/account.key ACCOUNT_EMAIL=some@valid.email ./le.sh install

See #121 for background (apparently github does not allow force pushing to already closed PR -  isaacs/github#361 , so I can't refresh the old one :-/)

changes compared to #121: use `_saveaccountconf` instead of `_sed_i`, check for default `$ACCOUNT_KEY_PATH`