### PR TITLE
fix renewAll bug

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -824,17 +824,17 @@ _initpath() {
     ACCOUNT_KEY_PATH="$_DEFAULT_ACCOUNT_KEY_PATH"
   fi
   
+  _DEFAULT_CERT_HOME="$LE_WORKING_DIR"
+  if [ -z "$CERT_HOME" ] ; then
+    CERT_HOME="$_DEFAULT_CERT_HOME"
+  fi
+
   domain="$1"
 
   if [ -z "$domain" ] ; then
     return 0
   fi
   
-  _DEFAULT_CERT_HOME="$LE_WORKING_DIR"
-  if [ -z "$CERT_HOME" ] ; then
-    CERT_HOME="$_DEFAULT_CERT_HOME"
-  fi
-
   domainhome="$CERT_HOME/$domain"
   mkdir -p "$domainhome"
 


### PR DESCRIPTION
$CERT_HOME is required by renewAll, but wasn't initialized.