### PR TITLE
Fix record update error for cloudxns

### DIFF
--- a/dnsapi/dns_cx.sh
+++ b/dnsapi/dns_cx.sh
@@ -69,7 +69,7 @@ existing_records() {
     return 1
   fi
   count=0
-  seg=$(printf "$response" | grep -o "{[^{]*host\":\"$_sub_domain[^}]*}")
+  seg=$(printf "$response" | grep -o "{[^{]*host\":\"$_sub_domain\"[^}]*}")
   _debug seg "$seg"
   if [ -z "$seg" ] ; then
     return 0


### PR DESCRIPTION
```
[Sat Apr 23 23:23:38 CST 2016] seg='{"record_id":"1141479","host_id":"829483","host":"_acme-challenge","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":""kW8HZmujDCIpWe0BkEDj1Ax6URdz3kQGm6U4Fd1SPsY"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-04-23 23:22:44","update_time":"2016-04-23 23:23:08"}
{"record_id":"1141481","host_id":"829485","host":"_acme-challenge.www","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":""Hxpi0HvjnvGVEydbY7GGTGVevP9P557cdsFJ4U3rlhc"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-04-23 23:22:45","update_time":"2016-04-23 23:23:09"}'
[Sat Apr 23 23:23:38 CST 2016] record_id='1141479
1141481'
[Sat Apr 23 23:23:38 CST 2016] count='1'
[Sat Apr 23 23:23:38 CST 2016] Updating record
[Sat Apr 23 23:23:38 CST 2016] record/1141479='1141481'
[Sat Apr 23 23:23:38 CST 2016] url='https://www.cloudxns.net/api2/record/1141479
1141481'
[Sat Apr 23 23:23:38 CST 2016] cdate='2016-04-23 15:23:38 UTC'
[Sat Apr 23 23:23:38 CST 2016] data='{"domain_id": 56917, "host":"_acme-challenge", "value":"rkE2OVCw7kBMRaYqZpwxPB5PcD8v681oKJ7bUGX4WhE", "type":"TXT","ttl":600, "line_id":1}'
[Sat Apr 23 23:23:38 CST 2016] sec='***************https://www.cloudxns.net/api2/record/1141479
1141481{"domain_id": 56917, "host":"_acme-challenge", "value":"rkE2OVCw7kBMRaYqZpwxPB5PcD8v681oKJ7bUGX4WhE", "type":"TXT","ttl":600, "line_id":1}2016-04-23 15:23:38 UTC***************'
[Sat Apr 23 23:23:38 CST 2016] error record/1141479
1141481
[Sat Apr 23 23:23:38 CST 2016] Error add txt for domain:_acme-challenge.example.com
```

While checking the dns record for root domain, the regex will match other subdomains' record.