### PR TITLE
fix Le_Webroot check

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1057,7 +1057,7 @@ issue() {
     Le_Keylength=""
   fi
   
-  if _contains "$Le_Webroot" "no" ; then
+  if [ "$Le_Webroot" = "no" ] ; then
     _info "Standalone mode."
     if ! _exists "nc" ; then
       _err "Please install netcat(nc) tools first."


### PR DESCRIPTION
Go for other options if it is equal to "no", not if it merely contains "no".

Not sure if fixed properly, just had to do that in order to use a webroot path that contains "no".