### PR TITLE
Bash does not support double equal sign

### DIFF
--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -45,7 +45,7 @@ dns_cf_add(){
   
   count=$(printf "$response" | grep -o \"count\":[^,]* | cut -d : -f 2)
   _debug count "$count"
-  if [ "$count" == "0" ] ; then
+  if [ "$count" = "0" ] ; then
     _info "Adding record"
     if _cf_rest POST "zones/$_domain_id/dns_records"  "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":120}"; then
       if printf $response | grep $fulldomain > /dev/null ; then
@@ -65,7 +65,7 @@ dns_cf_add(){
     _debug "record_id" $record_id
     
     _cf_rest PUT "zones/$_domain_id/dns_records/$record_id"  "{\"id\":\"$record_id\",\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"zone_id\":\"$_domain_id\",\"zone_name\":\"$_domain\"}"
-    if [ "$?" == "0" ]; then
+    if [ "$?" = "0" ]; then
       _info "Updated, sleeping 10 seconds"
       sleep 10
       #todo: check if the record takes effect


### PR DESCRIPTION
[Sat May 21 15:45:10 CEST 2016] count='0'
./acme.sh: 48: [: 0: unexpected operator
[Sat May 21 15:45:10 CEST 2016] Updating record