### PR TITLE
Add missing escape in regular expression.

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1725,7 +1725,7 @@ issue() {
       fi
       
       if [ "$status" = "invalid" ] ; then
-         error="$(echo $response | tr -d "\r\n" | egrep -o '"error":{[^}]*}')"
+         error="$(echo $response | tr -d "\r\n" | egrep -o '"error":\{[^}]*}')"
          _debug2 error "$error"
          errordetail="$(echo $error |  grep -o '"detail": *"[^"]*"' | cut -d '"' -f 4)"
          _debug2 errordetail "$errordetail"


### PR DESCRIPTION
There was a missing escape of a { character in one of the regular
expressions passed to grep. This adds that.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>