### PR TITLE
Support for shells without 'stat' (busybox ash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Wiki: https://github.com/Neilpang/acme.sh/wiki
 |14|-----| Cloud Linux  https://github.com/Neilpang/le/issues/111
 |15|[![](https://cdn.rawgit.com/Neilpang/acmetest/master/status/openbsd.svg)](https://github.com/Neilpang/letest#here-are-the-latest-status)|OpenBSD
 |16|[![](https://cdn.rawgit.com/Neilpang/acmetest/master/status/mageia.svg)](https://github.com/Neilpang/letest#here-are-the-latest-status)|Mageia
+|17|-----| OpenWRT: Tested and working. See [wiki page](https://github.com/Neilpang/acme.sh/wiki/How-to-run-on-OpenWRT)
 
 For all build statuses, check our [daily build project](https://github.com/Neilpang/acmetest): 
 

--- a/acme.sh
+++ b/acme.sh
@@ -549,6 +549,7 @@ _stat() {
   if stat -f  '%Su:%Sg' "$1" 2>/dev/null ; then
     return
   fi
+  return 3; #error, 'stat' not found
 }
 
 #keyfile
@@ -1656,9 +1657,12 @@ issue() {
         mkdir -p "$wellknown_path"
         printf "%s" "$keyauthorization" > "$wellknown_path/$token"
         if [ ! "$usingApache" ] ; then
-          webroot_owner=$(_stat $_currentRoot)
-          _debug "Changing owner/group of .well-known to $webroot_owner"
-          chown -R $webroot_owner "$_currentRoot/.well-known"
+          if webroot_owner=$(_stat $_currentRoot) ; then
+            _debug "Changing owner/group of .well-known to $webroot_owner"
+            chown -R $webroot_owner "$_currentRoot/.well-known"
+          else
+            _debug "not chaning owner/group of webroot";
+          fi
         fi
         
       fi

--- a/acme.sh
+++ b/acme.sh
@@ -549,7 +549,8 @@ _stat() {
   if stat -f  '%Su:%Sg' "$1" 2>/dev/null ; then
     return
   fi
-  return 3; #error, 'stat' not found
+  
+  return 1; #error, 'stat' not found
 }
 
 #keyfile


### PR DESCRIPTION
I successfully got acme.sh to work on OpenWRT using the internal busybox ash shell!
It required installing curl, ca-certificates, and adding `export SSL_CERT_DIR=/etc/ssl/certs` to /etc/profile. The only problem was when using the webroot verification option it tried to chown the created folder but couldn't use the `stat` command to get the correct permissions– that command doesn't exist in busybox.

My fix is simple:
- the _stat command can now return an error
- the issue() command chown command isn't run if _stat fails