### PR TITLE
Create private key files not world-readable

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -337,6 +337,18 @@ _createkey() {
     _info "Using ec name: $eccname"
   fi
 
+  # to prevent the key file from being world-readable
+  # create an empty file and chmod 600 before saving the key contents
+  if ! touch "$f"; then
+    _err "unable to create empty file '$f' for private key"
+    return 1
+  fi
+
+  if ! chmod 600 "$f"; then
+    _err "unable to chmod 600 key file $f"
+    return 1
+  fi
+
   #generate account key
   if [ "$isec" ] ; then
     openssl ecparam  -name $eccname -genkey 2>/dev/null > "$f"


### PR DESCRIPTION
One thing that I find annoying is that the private key files are create world-readable (e.g. when the user uses umask 022, that is the default mostly everywhere). On most cases this is not a problem, but on shared systems of universities, shared hosting companies, etc, it's a problem.

This pull request changes the _createKey() function to create private key files readable only by the user executing the script.