### PR TITLE
Added TTL to dns_lexicon.sh

### DIFF
--- a/dnsapi/dns_lexicon.sh
+++ b/dnsapi/dns_lexicon.sh
@@ -61,7 +61,7 @@ dns_lexicon_add() {
     _saveaccountconf $Lx_domaintoken "$Lx_domaintoken_v"
   fi
 
-  $lexicon_cmd "$PROVIDER" create ${domain} TXT --name="_acme-challenge.${domain}." --content="${txtvalue}"
+  $lexicon_cmd "$PROVIDER" create ${domain} TXT --name="_acme-challenge.${domain}." --content="${txtvalue}" --ttl=120
 
 }
 


### PR DESCRIPTION
Realized missing `--ttl` parameter while debugging and ultimately discovering that there is a bug (or actually completely missing functionality) in lexicon that causes the parameter currently not to be processed at all, but I submitted an issue for it too. (https://github.com/AnalogJ/lexicon/issues/49)
