### PR TITLE
dns_cx.sh prefix and suffix domain bug fixed

### DIFF
--- a/dnsapi/dns_cx.sh
+++ b/dnsapi/dns_cx.sh
@@ -145,7 +145,7 @@ _get_root() {
     fi
 
     if printf "$response" | grep "$h." >/dev/null ; then
-      seg=$(printf "$response" | grep -o "{[^{]*$h\.[^}]*\}" )
+      seg=$(printf "$response" | grep -o "{[^{]*\"$h\.\"[^}]*\}" )
       _debug seg "$seg"
       _domain_id=$(printf "$seg" | grep -o \"id\":\"[^\"]*\" | cut -d : -f 2 | tr -d \")
       _debug _domain_id "$_domain_id"


### PR DESCRIPTION
If we have multi domain in Cloudxns, such as:  "acme.sh", "**acme.sh**.sh", "acme.**acme.sh**".
When we issue a cert for "**acme.sh**", all of the domains are matched!
We must exactly determine the domain.
The Cloudxns rest api return json data, so we can match the domain use double quotation marks in grep command.