### PR TITLE
Add option for a custom ca-bundle file.

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -743,6 +743,10 @@ _inithttp() {
       CURL="$CURL --trace-ascii $_CURL_DUMP "
     fi
 
+    if [ "$CACERT_BUNDLE" ] ; then
+      CURL="$CURL --cacert $CACERT_BUNDLE "
+    fi
+
     if [ "$HTTPS_INSECURE" ] ; then
       CURL="$CURL --insecure  "
     fi
@@ -752,6 +756,9 @@ _inithttp() {
     WGET="wget -q"
     if [ "$DEBUG" ] && [ "$DEBUG" -ge "2" ] ; then
       WGET="$WGET -d "
+    fi
+    if [ "$CACERT_BUNDLE" ] ; then
+      WGET="$WGET --ca-certificate $CACERT_BUNDLE "
     fi
     if [ "$HTTPS_INSECURE" ] ; then
       WGET="$WGET --no-check-certificate "
@@ -2770,6 +2777,7 @@ Parameters:
   --listraw                         Only used for '--list' command, list the certs in raw format.
   --stopRenewOnError, -se           Only valid for '--renewall' command. Stop if one cert has error in renewal.
   --insecure                        Do not check the server certificate, in some devices, the api server's certificate may not be trusted.
+  --cacert                          Specifices the path to the cacert bundle to verify api server's certificate.
   --nocron                          Only valid for '--install' command, which means: do not install the default cron job. In this case, the certs will not be renewed automatically.
   --ecc                             Specifies to use the ECC cert. Valid for '--installcert', '--renew', '--revoke', '--toPkcs' and '--createCSR'
   "
@@ -2844,6 +2852,7 @@ _process() {
   _listraw=""
   _stopRenewOnError=""
   _insecure=""
+  _cacert=""
   _nocron=""
   _ecc=""
   while [ ${#} -gt 0 ] ; do
@@ -3085,6 +3094,11 @@ _process() {
     --insecure)
         _insecure="1"
         HTTPS_INSECURE="1"
+        ;;
+    --cacert)
+        _cacert="$2"
+        CACERT_BUNDLE="$_cacert"
+        shift
         ;;
     --nocron)
         _nocron="1"

--- a/acme.sh
+++ b/acme.sh
@@ -743,8 +743,8 @@ _inithttp() {
       CURL="$CURL --trace-ascii $_CURL_DUMP "
     fi
 
-    if [ "$CACERT_BUNDLE" ] ; then
-      CURL="$CURL --cacert $CACERT_BUNDLE "
+    if [ "$CA_BUNDLE" ] ; then
+      CURL="$CURL --cacert $CA_BUNDLE "
     fi
 
     if [ "$HTTPS_INSECURE" ] ; then
@@ -757,8 +757,8 @@ _inithttp() {
     if [ "$DEBUG" ] && [ "$DEBUG" -ge "2" ] ; then
       WGET="$WGET -d "
     fi
-    if [ "$CACERT_BUNDLE" ] ; then
-      WGET="$WGET --ca-certificate $CACERT_BUNDLE "
+    if [ "$CA_BUNDLE" ] ; then
+      WGET="$WGET --ca-certificate $CA_BUNDLE "
     fi
     if [ "$HTTPS_INSECURE" ] ; then
       WGET="$WGET --no-check-certificate "
@@ -2777,7 +2777,7 @@ Parameters:
   --listraw                         Only used for '--list' command, list the certs in raw format.
   --stopRenewOnError, -se           Only valid for '--renewall' command. Stop if one cert has error in renewal.
   --insecure                        Do not check the server certificate, in some devices, the api server's certificate may not be trusted.
-  --cacert                          Specifices the path to the cacert bundle to verify api server's certificate.
+  --ca-bundle                       Specifices the path to the CA certificate bundle to verify api server's certificate.
   --nocron                          Only valid for '--install' command, which means: do not install the default cron job. In this case, the certs will not be renewed automatically.
   --ecc                             Specifies to use the ECC cert. Valid for '--installcert', '--renew', '--revoke', '--toPkcs' and '--createCSR'
   "
@@ -2852,7 +2852,7 @@ _process() {
   _listraw=""
   _stopRenewOnError=""
   _insecure=""
-  _cacert=""
+  _ca_bundle=""
   _nocron=""
   _ecc=""
   while [ ${#} -gt 0 ] ; do
@@ -3095,9 +3095,9 @@ _process() {
         _insecure="1"
         HTTPS_INSECURE="1"
         ;;
-    --cacert)
-        _cacert="$2"
-        CACERT_BUNDLE="$_cacert"
+    --ca-bundle)
+        _ca_bundle="$2"
+        CA_BUNDLE="$_ca_bundle"
         shift
         ;;
     --nocron)

--- a/acme.sh
+++ b/acme.sh
@@ -2064,6 +2064,12 @@ issue() {
     _savedomainconf  "Le_RenewalDays"   "$Le_RenewalDays"
   fi
   
+  if [ "$CA_BUNDLE" ] ; then
+    _saveaccountconf CA_BUNDLE "$CA_BUNDLE"
+  else
+    _clearaccountconf "CA_BUNDLE"
+  fi
+
   if [ "$HTTPS_INSECURE" ] ; then
     _saveaccountconf HTTPS_INSECURE "$HTTPS_INSECURE"
   else

--- a/acme.sh
+++ b/acme.sh
@@ -3102,7 +3102,7 @@ _process() {
         HTTPS_INSECURE="1"
         ;;
     --ca-bundle)
-        _ca_bundle="$2"
+        _ca_bundle=$(readlink -f $2)
         CA_BUNDLE="$_ca_bundle"
         shift
         ;;


### PR DESCRIPTION
Sometimes an OS comes without a default ca-cert bundle file. This option allows one to point curl or wget to a CA certificate bundle file.