### PR TITLE
Allow saved password strings to have special characters.

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1180,7 +1180,7 @@ _saveaccountconf() {
   _sckey="$1"
   _scvalue="$2"
   if [ "$ACCOUNT_CONF_PATH" ] ; then
-    _setopt "$ACCOUNT_CONF_PATH" "$_sckey" "=" "\"$_scvalue\""
+    _setopt "$ACCOUNT_CONF_PATH" "$_sckey" "=" "'$_scvalue'"
   else
     _err "ACCOUNT_CONF_PATH is empty, can not save $_sckey=$_scvalue"
   fi


### PR DESCRIPTION
When saving passwords with special characters, each save modifies the value of the saved variable, as it is evaluated as a string.

(Not sure what the right terms are here, but the single quote takes a string "as-is", instead of trying to evaluate the contents)

This PR saves the account config variables with single instead of double quotes.

Not sure if this breaks anything else, so I would appreciate your feedback @Neilpang 