### PR TITLE
bash support for luadns api

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ You don't have do anything manually!
 7. PowerDNS API
 8. lexicon dns api: https://github.com/Neilpang/acme.sh/wiki/How-to-use-lexicon-dns-api
    (DigitalOcean, DNSimple, DnsMadeEasy, DNSPark, EasyDNS, Namesilo, NS1, PointHQ, Rage4 and Vultr etc.)
+9. LuaDNS.com API
 
 ##### More APIs are coming soon...
 

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -136,4 +136,22 @@ For more details, please check our sample script: [dns_myapi.sh](dns_myapi.sh)
 
 https://github.com/Neilpang/acme.sh/wiki/How-to-use-lexicon-dns-api
 
+## Use LuaDNS domain API
+
+Get your API token at https://api.luadns.com/settings
+
+```
+export LUA_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
+
+export LUA_Email="xxxx@sss.com"
+
+```
+
+To issue a cert:
+```
+acme.sh   --issue   --dns dns_lua --dnssleep 3  -d example.com  -d www.example.com
+```
+
+The `LUA_Key` and `LUA_Email`  will be saved in `~/.acme.sh/account.conf`, and will be reused when needed.
+
 

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+
+#
+#LUA_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
+#
+#LUA_Email="xxxx%40sss.com"
+
+LUA_Api="https://api.luadns.com/v1"
+LUA_auth=$(printf $LUA_Email:$LUA_Key | base64)
+# _ACME_CURL="curl -L --silent -u $LUA_Email:$LUA_Key "
+
+#printf $LUA_Api
+#exit
+########  Public functions #####################
+
+#Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_lua_add() {
+  fulldomain=$1
+  txtvalue=$2
+  
+  if [ -z "$LUA_Key" ] || [ -z "$LUA_Email" ] ; then
+    _err "You don't specify luadns api key and email yet."
+    _err "Please create you key and try again."
+    return 1
+  fi
+  
+  #save the api key and email to the account conf file.
+  _saveaccountconf LUA_Key "$LUA_Key"
+  _saveaccountconf LUA_Email "$LUA_Email"
+  
+  _debug "First detect the root zone"
+  if ! _get_root $fulldomain ; then
+    _err "invalid domain"
+    return 1
+  fi
+  _debug _domain_id "$_domain_id"
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
+  
+  _debug "Getting txt records"
+  _LUA_rest GET "zones/${_domain_id}/records"
+  
+  if ! printf "$response" | grep \"id\": > /dev/null ; then
+    _err "Error"
+    return 1
+  fi
+  
+  count=$(printf "%s\n" "$response" | _egrep_o \"name\":\"$fulldomain\" | wc -l)
+  _debug count "$count"
+  if [ "$count" = "0" ] ; then
+    _info "Adding record"
+    if _LUA_rest POST "zones/$_domain_id/records"  "{\"type\":\"TXT\",\"name\":\"$fulldomain.\",\"content\":\"$txtvalue\",\"ttl\":120}"; then
+      if printf -- "%s" "$response" | grep $fulldomain > /dev/null ; then
+        _info "Added"
+        #todo: check if the record takes effect
+        return 0
+      else
+        _err "Add txt record error."
+        return 1
+      fi
+    fi
+    _err "Add txt record error."
+  else
+    _info "Updating record"
+    record_id=$(printf "%s\n" "$response" | _egrep_o \"id\":[^,]*,\"name\":\"$fulldomain.\",\"type\":\"TXT\" | cut -d: -f2|cut -d, -f1 )
+    _debug "record_id" $record_id
+    
+    _LUA_rest PUT "zones/$_domain_id/records/$record_id"  "{\"id\":\"$record_id\",\"type\":\"TXT\",\"name\":\"$fulldomain.\",\"content\":\"$txtvalue\",\"zone_id\":\"$_domain_id\",\"ttl\":120}"
+    if [ "$?" = "0" ]; then
+      _info "Updated!"
+      #todo: check if the record takes effect
+      return 0;
+    fi
+    _err "Update error"
+    return 1
+  fi
+  
+}
+
+
+#fulldomain
+dns_lua_rm() {
+  fulldomain=$1
+
+}
+
+
+####################  Private functions bellow ##################################
+#_acme-challenge.www.domain.com
+#returns
+# _sub_domain=_acme-challenge.www
+# _domain=domain.com
+# _domain_id=sdjkglgdfewsdfg
+_get_root() {
+  domain=$1
+  i=2
+  p=1
+    if ! _LUA_rest GET "zones" ; then
+      return 1
+    fi
+	while [ '1' ] ; do
+    h=$(printf $domain | cut -d . -f $i-100)
+    if [ -z "$h" ] ; then
+      #not valid
+      return 1;
+    fi
+    
+    if printf $response | grep \"name\":\"$h\" >/dev/null ; then
+      _domain_id=$(printf "%s\n" "$response" | _egrep_o \"id\":[^,]*,\"name\":\"$h\" | cut -d : -f 2 | cut -d , -f 1)
+      if [ "$_domain_id" ] ; then
+        _sub_domain=$(printf $domain | cut -d . -f 1-$p)
+        _domain=$h
+        return 0
+      fi
+      return 1
+    fi
+    p=$i
+    i=$(expr $i + 1)
+  done
+  return 1
+}
+
+_LUA_rest() {
+  m=$1
+  ep="$2"
+  data="$3"
+  _debug $ep
+  
+  _H1="Accept: application/json"
+  _H2="Authorization: Basic $LUA_auth"
+  if [ "$data" ] ; then
+    _debug data "$data"
+    response="$(_post "$data" "$LUA_Api/$ep" "" $m)"
+  else
+    response="$(_get "$LUA_Api/$ep")"
+  fi
+  
+  if [ "$?" != "0" ] ; then
+    _err "error $ep"
+    return 1
+  fi
+  _debug2 response "$response"
+  return 0
+}
+
+

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 
 #

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
+# bug reports to justmwa@users.noreply.github.com
 
 #
 #LUA_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -4,14 +4,11 @@
 #
 #LUA_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
 #
-#LUA_Email="xxxx%40sss.com"
+#LUA_Email="user@luadns.net"
 
 LUA_Api="https://api.luadns.com/v1"
 LUA_auth=$(printf $LUA_Email:$LUA_Key | base64)
-# _ACME_CURL="curl -L --silent -u $LUA_Email:$LUA_Key "
 
-#printf $LUA_Api
-#exit
 ########  Public functions #####################
 
 #Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -7,7 +7,7 @@
 #LUA_Email="user@luadns.net"
 
 LUA_Api="https://api.luadns.com/v1"
-LUA_auth=$(printf $LUA_Email:$LUA_Key | base64)
+LUA_auth=$(printf $LUA_Email:$LUA_Key | _base64)
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# bug reports to justmwa@users.noreply.github.com
+# bug reports to dev@1e.ca
 
 #
 #LUA_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"


### PR DESCRIPTION
hey,
luadns.com has a nice api that doesn't need the bloat of lexicon to be used and since there's a free tier, all the better.
auth is used with base64 since I coudln't figure how to put email%40domain in the https query properly, and I didn't want to alter the main script to add '-u user:pass' support.
