### PR TITLE
add API for www.do.de/www.resellerinterface.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ You don't have to do anything manually!
 1. Linode.com API
 1. FreeDNS (https://freedns.afraid.org/)
 1. cyon.ch
+1. Domain-Offensive/Resellerinterface/Domainrobot API
 
 **More APIs coming soon...**
 

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -240,6 +240,7 @@ acme.sh --issue --dns dns_ispconfig -d example.com -d www.example.com
 
 The `ISPC_User`, `ISPC_Password`, `ISPC_Api`and `ISPC_Api_Insecure` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
+<<<<<<< HEAD
 ## 13. Use Alwaysdata domain API
 
 First you need to login to your Alwaysdata account to get your API Key.
@@ -322,6 +323,19 @@ acme.sh --issue --dns dns_cyon -d example.com -d www.example.com
 ```
 
 The `CY_Username`, `CY_Password` and `CY_OTP_Secret` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+
+## 17. Use Domain-Offensive/Resellerinterface/Domainrobot API
+
+You will need your login credentials (Partner ID+Password) to the Resellerinterface, and export them before you run `acme.sh`:
+```
+export DO_PID="KD-1234567"
+export DO_PW="cdfkjl3n2"
+```
+
+Ok, let's issue a cert now:
+```
+acme.sh --issue --dns dns_do -d example.com -d www.example.com
+```
 
 # Use custom API
 

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -240,7 +240,6 @@ acme.sh --issue --dns dns_ispconfig -d example.com -d www.example.com
 
 The `ISPC_User`, `ISPC_Password`, `ISPC_Api`and `ISPC_Api_Insecure` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
-<<<<<<< HEAD
 ## 13. Use Alwaysdata domain API
 
 First you need to login to your Alwaysdata account to get your API Key.

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -27,7 +27,6 @@ dns_do_add() {
 #fulldomain
 dns_do_rm() {
   fulldomain=$1
-  _cookiejar="$(_mktemp)"
   if _dns_do_authenticate; then
     if _dns_do_list_rrs; then
       _dns_do_had_error=0

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -115,9 +115,11 @@ _get_root() {
   domain=$1
   i=1
 
-  _all_domains="$(_mktemp)"
   _dns_do_soap getDomainList
-  echo "${response}" | tr -d "\n\r\t " | _egrep_o 'domain</key><value[^>]+>[^<]+' | sed -e 's/^domain<\/key><value[^>]+>//g' >"${_all_domains}"
+  _all_domains="/$(echo "${response}" \
+    | tr -d "\n\r\t " \
+    | _egrep_o 'domain</key><value[^>]+>[^<]+' \
+    | sed -e 's/^domain<\/key><value[^>]*>//g')"
 
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)
@@ -125,7 +127,7 @@ _get_root() {
       return 1
     fi
 
-    if grep -q "$(_regexcape "$h")" "${_all_domains}"; then
+    if _contains "${_all_domains}" "^$(_regexcape "$h")\$"; then
       _domain="$h"
       return 0
     fi

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env sh
+
+# DNS API for Domain-Offensive / Resellerinterface / Domainrobot
+
+# DO_PID="KD-1234567"
+# DO_PW="cdfkjl3n2"
+
+DO_URL="https://soap.resellerinterface.de/"
+
+########  Public functions #####################
+
+#Usage: dns_myapi_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_do_add() {
+  fulldomain=$1
+  txtvalue=$2
+  _cookiejar="$(_mktemp)"
+  if _dns_do_authenticate; then
+    _info "Adding TXT record to ${_domain} as ${fulldomain}"
+    _dns_do_soap createRR origin "${_domain}" name "${fulldomain}" type TXT data "${txtvalue}" ttl 300
+    if _contains "${response}" '>success<'; then
+      return 0
+    fi
+    _err "Could not create resource record, check logs"
+  fi
+  return 1
+}
+
+#fulldomain
+dns_do_rm() {
+  fulldomain=$1
+  _cookiejar="$(_mktemp)"
+  if _dns_do_authenticate; then
+    if _dns_do_list_rrs; then
+      for _rrid in ${_rr_list}; do
+        _info "Deleting resource record $_rrid for $_domain"
+        _dns_do_soap deleteRR origin "${_domain}" rrid "${_rrid}"
+        if ! _contains "${response}" '>success<'; then
+          _err "Could not delete resource record for ${_domain}, id ${_rrid}"
+        fi
+      done
+      return 0
+    fi
+  fi
+  return 1
+}
+
+####################  Private functions below ##################################
+_dns_do_authenticate() {
+  _info "Authenticating as ${DO_PID}"
+  _dns_do_soap authPartner partner "${DO_PID}" password "${DO_PW}"
+  if _contains "${response}" '>success<'; then
+    _get_root "$fulldomain"
+    _debug "_domain $_domain"
+    return 0
+  else
+    _err "Authentication failed, check logs"
+  fi
+  return 1
+}
+
+_dns_do_list_rrs() {
+  _dns_do_soap getRRList origin "${_domain}"
+  if ! _contains "${response}" 'SOAP-ENC:Array'; then
+    _err "getRRList origin ${_domain} failed"
+    return 1
+  fi
+  _rr_list="$(echo "${response}" \
+    | tr -d "\n\r\t" \
+    | sed -e 's/<item xsi:type="ns2:Map">/\n/g' \
+    | grep -F ">${fulldomain}</value>" \
+    | sed -e 's/<item>/\n\0/g' \
+    | grep -F '>id</key>' \
+    | sed -re 's/.*<value[^>]*>([^<]+)<\/value>.*/\1/')"
+  [ "${_rr_list}" ]
+}
+
+_dns_do_soap() {
+  func="$1"
+  shift
+  # put the parameters to xml
+  body="<tns:${func} xmlns:tns=\"${DO_URL}\">"
+  while [ "$1" ] ; do
+    _k="$1"
+    shift
+    _v="$1"
+    shift
+    body="$body<$_k>$_v</$_k>"
+  done
+  body="$body</tns:${func}>"
+  _debug2 "SOAP request ${body}"
+
+  # build SOAP XML
+  _xml='<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Body>'"$body"'</env:Body>
+</env:Envelope>'
+
+  # set SOAP headers
+  _H1="SOAPAction: ${DO_URL}#${func}"
+  # add cookie header if present
+  [ -s "${_cookiejar}" ] && _H2="$(cat "${_cookiejar}")"
+
+  if ! response="$(_post "${_xml}" "${DO_URL}")"; then
+    _err "Error <$1>"
+    return 1
+  fi
+  _debug2 "SOAP response $response"
+
+  # retrieve cookie header
+  grep -F 'Set-Cookie:' "$HTTP_HEADER" | sed -re 's/^Set-(Cookie: [^;]+).*/\1/' | head -1 > "${_cookiejar}"
+
+  return 0
+}
+
+_get_root() {
+  domain=$1
+  i=1
+
+  _all_domains="$(_mktemp)"
+  _dns_do_soap getDomainList
+  echo "${response}" | tr -d "\n\r\t " | grep -Eo 'domain</key><value[^>]+>[^<]+' | sed -re 's/^domain<\/key><value[^>]+>//g' > "${_all_domains}"
+
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
+    if [ -z "$h" ]; then
+      return 1
+    fi
+
+    if grep -qF "$h" "${_all_domains}"; then
+      _domain="$h"
+      return 0
+    fi
+
+    i=$(_math $i + 1)
+  done
+  _debug "$domain not found"
+
+  return 1
+}
+
+_info() {
+  if [ -z "$2" ]; then
+    echo "[$(date)] $1"
+  else
+    echo "[$(date)] $1='$2'"
+  fi
+}
+
+_err() {
+  _info "$@" >&2
+  return 1
+}
+
+_debug() {
+  if [ -z "$DEBUG" ]; then
+    return
+  fi
+  _err "$@"
+  return 0
+}
+
+_debug2() {
+  if [ "$DEBUG" ] && [ "$DEBUG" -ge "2" ]; then
+    _debug "$@"
+  fi
+  return
+}

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -100,7 +100,7 @@ _dns_do_soap() {
 </env:Envelope>'
 
   # set SOAP headers
-  _H1="SOAPAction: ${DO_URL}#${func}"
+  export _H1="SOAPAction: ${DO_URL}#${func}"
 
   if ! response="$(_post "${_xml}" "${DO_URL}")"; then
     _err "Error <$1>"
@@ -109,7 +109,7 @@ _dns_do_soap() {
   _debug2 "SOAP response $response"
 
   # retrieve cookie header
-  _H2="$(_egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | _head_n 1)"
+  export _H2="$(_egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | _head_n 1)"
 
   return 0
 }

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -80,7 +80,7 @@ _dns_do_soap() {
   shift
   # put the parameters to xml
   body="<tns:${func} xmlns:tns=\"${DO_URL}\">"
-  while [ "$1" ] ; do
+  while [ "$1" ]; do
     _k="$1"
     shift
     _v="$1"
@@ -108,7 +108,7 @@ _dns_do_soap() {
   _debug2 "SOAP response $response"
 
   # retrieve cookie header
-  cat "$HTTP_HEADER" | _egrep_o 'Cookie: [^;]+' | head -1 > "${_cookiejar}"
+  _egrep_o 'Cookie: [^;]+' < "$HTTP_HEADER" | head -1 >"${_cookiejar}"
 
   return 0
 }
@@ -119,7 +119,7 @@ _get_root() {
 
   _all_domains="$(_mktemp)"
   _dns_do_soap getDomainList
-  echo "${response}" | tr -d "\n\r\t " | _egrep_o 'domain</key><value[^>]+>[^<]+' | sed -e 's/^domain<\/key><value[^>]+>//g' > "${_all_domains}"
+  echo "${response}" | tr -d "\n\r\t " | _egrep_o 'domain</key><value[^>]+>[^<]+' | sed -e 's/^domain<\/key><value[^>]+>//g' >"${_all_domains}"
 
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -53,7 +53,7 @@ _dns_do_authenticate() {
     _debug "_domain $_domain"
     return 0
   else
-    _err "Authentication failed, check logs"
+    _err "Authentication failed, are DO_PID and DO_PW set correctly?"
   fi
   return 1
 }

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -119,7 +119,7 @@ _get_root() {
   i=1
 
   _dns_do_soap getDomainList
-  _all_domains="/$(echo "${response}" \
+  _all_domains="$(echo "${response}" \
     | tr -d "\n\r\t " \
     | _egrep_o 'domain</key><value[^>]+>[^<]+' \
     | sed -e 's/^domain<\/key><value[^>]*>//g')"

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -67,7 +67,7 @@ _dns_do_list_rrs() {
   _rr_list="$(echo "${response}" \
     | tr -d "\n\r\t" \
     | sed -e 's/<item xsi:type="ns2:Map">/\n/g' \
-    | fgrep ">${fulldomain}</value>" \
+    | grep ">$(_regexcape "$fulldomain")</value>" \
     | sed -e 's/<\/item>/\n/g' \
     | grep '>id</key><value' \
     | _egrep_o '>[0-9]{1,16}<' \
@@ -127,7 +127,7 @@ _get_root() {
       return 1
     fi
 
-    if fgrep -q "$h" "${_all_domains}"; then
+    if grep -q "$(_regexcape "$h")" "${_all_domains}"; then
       _domain="$h"
       return 0
     fi
@@ -137,4 +137,8 @@ _get_root() {
   _debug "$domain not found"
 
   return 1
+}
+
+_regexcape() {
+  echo "$1" | sed -e 's/\([]\.$*^[]\)/\\\1/g'
 }

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -38,7 +38,7 @@ dns_do_rm() {
           _err "Could not delete resource record for ${_domain}, id ${_rrid}"
         fi
       done
-      return _dns_do_had_error
+      return $_dns_do_had_error
     fi
   fi
   return 1

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -2,6 +2,9 @@
 
 # DNS API for Domain-Offensive / Resellerinterface / Domainrobot
 
+# Report bugs at https://github.com/seidler2547/acme.sh/issues
+
+# set these environment variables to match your customer ID and password:
 # DO_PID="KD-1234567"
 # DO_PW="cdfkjl3n2"
 
@@ -106,7 +109,7 @@ _dns_do_soap() {
   _debug2 "SOAP response $response"
 
   # retrieve cookie header
-  _H2="$(_egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | head -1)"
+  _H2="$(_egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | _head_n 1)"
 
   return 0
 }

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -30,14 +30,16 @@ dns_do_rm() {
   _cookiejar="$(_mktemp)"
   if _dns_do_authenticate; then
     if _dns_do_list_rrs; then
+      _dns_do_had_error=0
       for _rrid in ${_rr_list}; do
         _info "Deleting resource record $_rrid for $_domain"
         _dns_do_soap deleteRR origin "${_domain}" rrid "${_rrid}"
         if ! _contains "${response}" '>success<'; then
+          _dns_do_had_error=1
           _err "Could not delete resource record for ${_domain}, id ${_rrid}"
         fi
       done
-      return 0
+      return _dns_do_had_error
     fi
   fi
   return 1

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -98,8 +98,6 @@ _dns_do_soap() {
 
   # set SOAP headers
   _H1="SOAPAction: ${DO_URL}#${func}"
-  # add cookie header if present
-  [ -s "${_cookiejar}" ] && _H2="$(cat "${_cookiejar}")"
 
   if ! response="$(_post "${_xml}" "${DO_URL}")"; then
     _err "Error <$1>"
@@ -108,7 +106,7 @@ _dns_do_soap() {
   _debug2 "SOAP response $response"
 
   # retrieve cookie header
-  _egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | head -1 >"${_cookiejar}"
+  _H2="$(_egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | head -1)"
 
   return 0
 }

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -109,7 +109,8 @@ _dns_do_soap() {
   _debug2 "SOAP response $response"
 
   # retrieve cookie header
-  export _H2="$(_egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | _head_n 1)"
+  _H2="$(_egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | _head_n 1)"
+  export _H2
 
   return 0
 }

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -108,7 +108,7 @@ _dns_do_soap() {
   _debug2 "SOAP response $response"
 
   # retrieve cookie header
-  _egrep_o 'Cookie: [^;]+' < "$HTTP_HEADER" | head -1 >"${_cookiejar}"
+  _egrep_o 'Cookie: [^;]+' <"$HTTP_HEADER" | head -1 >"${_cookiejar}"
 
   return 0
 }

--- a/dnsapi/dns_do.sh
+++ b/dnsapi/dns_do.sh
@@ -13,7 +13,6 @@ DO_URL="https://soap.resellerinterface.de/"
 dns_do_add() {
   fulldomain=$1
   txtvalue=$2
-  _cookiejar="$(_mktemp)"
   if _dns_do_authenticate; then
     _info "Adding TXT record to ${_domain} as ${fulldomain}"
     _dns_do_soap createRR origin "${_domain}" name "${fulldomain}" type TXT data "${txtvalue}" ttl 300


### PR DESCRIPTION
First attempt to add the DNS API for Domain-Offensive (www.do.de). I don't know if the API is also available to standard customers, but it is for resellers (hence the domain resellerinterface.de). It seems like the same SOAP API is also used by various other DNS providers under the name Domainrobot.

Parsing XML in shell isn't funny, but I didn't want to introduce a dependency like xmlstarlet.