### PR TITLE
Fix AWS Route53 API consumer

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -72,7 +72,7 @@ _get_root() {
       fi
 
       if _contains "$response" "<Name>$h.</Name>"; then
-        hostedzone="$(echo "$response" | _egrep_o "<HostedZone>.*<Name>$h.</Name>.*</HostedZone>")"
+        hostedzone="$(echo "$response" | sed 's/<HostedZone>/\n&/g' | _egrep_o "<HostedZone>.*<Name>$h.</Name>.*</HostedZone>")"
         _debug hostedzone "$hostedzone"
         if [ -z "$hostedzone" ]; then
           _err "Error, can not get hostedzone."


### PR DESCRIPTION
Ignoring the Chthlulu argument :smiley:, Route53 returns its XML all on one line, making not possible to grep the hosted zone record with egrep/sed.

This change splits the XML in multiple lines, so that parsing can succeed.

Tested on Amazon Linux 2016.09, with
grep (GNU grep) 2.20
GNU sed version 4.2.1

Cheers,
