### PR TITLE
include dnsimple api

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ You don't have to do anything manually!
 
 1. CloudFlare.com API
 1. DNSPod.cn API
+1. DNSimple API
 1. CloudXNS.com API
 1. GoDaddy.com API
 1. OVH, kimsufi, soyoustart and runabove API

--- a/acme.sh
+++ b/acme.sh
@@ -1592,12 +1592,17 @@ _post() {
   return $_ret
 }
 
-# url getheader timeout
 _get() {
-  _debug GET
+  _request "$1" "$2" "$3" GET
+}
+
+# url getheader timeout
+_request() {
   url="$1"
   onlyheader="$2"
   t="$3"
+  method="$4"
+  _debug method $method
   _debug url "$url"
   _debug "timeout" "$t"
 
@@ -1610,6 +1615,9 @@ _get() {
     fi
     if [ "$t" ]; then
       _CURL="$_CURL --connect-timeout $t"
+    fi
+    if [ "$method" ]; then
+      _CURL="$_CURL -X $method"
     fi
     _debug "_CURL" "$_CURL"
     if [ "$onlyheader" ]; then
@@ -1632,6 +1640,9 @@ _get() {
     fi
     if [ "$t" ]; then
       _WGET="$_WGET --timeout=$t"
+    fi
+    if [ "$method" ]; then
+      _WGET="$_WGET --method=$method"
     fi
     _debug "_WGET" "$_WGET"
     if [ "$onlyheader" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -1592,17 +1592,12 @@ _post() {
   return $_ret
 }
 
-_get() {
-  _request "$1" "$2" "$3" GET
-}
-
 # url getheader timeout
-_request() {
+_get() {
+  _debug GET
   url="$1"
   onlyheader="$2"
   t="$3"
-  method="$4"
-  _debug method $method
   _debug url "$url"
   _debug "timeout" "$t"
 
@@ -1615,9 +1610,6 @@ _request() {
     fi
     if [ "$t" ]; then
       _CURL="$_CURL --connect-timeout $t"
-    fi
-    if [ "$method" ]; then
-      _CURL="$_CURL -X $method"
     fi
     _debug "_CURL" "$_CURL"
     if [ "$onlyheader" ]; then
@@ -1640,9 +1632,6 @@ _request() {
     fi
     if [ "$t" ]; then
       _WGET="$_WGET --timeout=$t"
-    fi
-    if [ "$method" ]; then
-      _WGET="$_WGET --method=$method"
     fi
     _debug "_WGET" "$_WGET"
     if [ "$onlyheader" ]; then

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -491,6 +491,9 @@ acme.sh --issue --dns dns_dnsimple -d example.com
 The `DNSimple_OAUTH_TOKEN` will be saved in `~/.acme.sh/account.conf` and will
 be reused when needed.
 
+If you have any issues with this integration please report them to
+https://github.com/pho3nixf1re/acme.sh/issues.
+
 # Use custom API
 
 If your API is not supported yet, you can write your own DNS API.

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -422,31 +422,31 @@ acme.sh --issue --dns dns_cloudns -d example.com -d www.example.com
 ```
 
 ## 22. Use Infoblox API
- 
+
 First you need to create/obtain API credentials on your Infoblox appliance.
- 
+
 ```
 export Infoblox_Creds="username:password"
 export Infoblox_Server="ip or fqdn of infoblox appliance"
 ```
- 
+
 Ok, let's issue a cert now:
 ```
 acme.sh --issue --dns dns_infoblox -d example.com -d www.example.com
 ```
- 
+
 Note: This script will automatically create and delete the ephemeral txt record.
 The `Infoblox_Creds` and `Infoblox_Server` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
 
 ## 23. Use VSCALE API
- 
+
 First you need to create/obtain API tokens on your [settings panel](https://vscale.io/panel/settings/tokens/).
- 
+
 ```
 VSCALE_API_KEY="sdfsdfsdfljlbjkljlkjsdfoiwje"
 ```
- 
+
 Ok, let's issue a cert now:
 ```
 acme.sh --issue --dns dns_vscale -d example.com -d www.example.com
@@ -468,6 +468,28 @@ acme.sh --issue --dns dns_dynu -d example.com -d www.example.com
 
 The `Dynu_ClientId` and `Dynu_Secret` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
+## 25. Use DNSimple API
+
+First you need to login to your DNSimple account and generate a new oauth token.
+
+https://dnsimple.com/a/{your account id}/account/access_tokens
+
+Note that this is an _account_ token and not a user token. The account token is
+needed to infer the `account_id` used in requests. A user token will not be able
+to determine the correct account to use.
+
+```
+export DNSimple_OAUTH_TOKEN="sdfsdfsdfljlbjkljlkjsdfoiwje"
+```
+
+To issue the cert just specify the `dns_dnsimple` API.
+
+```
+acme.sh --issue --dns dns_dnsimple -d example.com
+```
+
+The `DNSimple_OAUTH_TOKEN` will be saved in `~/.acme.sh/account.conf` and will
+be reused when needed.
 
 # Use custom API
 

--- a/dnsapi/dns_dnsimple.sh
+++ b/dnsapi/dns_dnsimple.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
 # DNSimple domain api
+# https://github.com/pho3nixf1re/acme.sh/issues
 #
 # This is your oauth token which can be acquired on the account page. Please
 # note that this must be an _account_ token and not a _user_ token.

--- a/dnsapi/dns_dnsimple.sh
+++ b/dnsapi/dns_dnsimple.sh
@@ -198,12 +198,12 @@ _dnsimple_rest() {
   export _H1="Accept: application/json"
   export _H2="Authorization: Bearer $DNSimple_OAUTH_TOKEN"
 
-  if [ "$data" ]; then
+  if [ "$data" ] || [ "$method" = "DELETE" ]; then
     _H1="Content-Type: application/json"
     _debug data "$data"
     response="$(_post "$data" "$request_url" "" "$method")"
   else
-    response="$(_request "$request_url" "" "" "$method")"
+    response="$(_get "$request_url" "" "" "$method")"
   fi
 
   if [ "$?" != "0" ]; then

--- a/dnsapi/dns_dnsimple.sh
+++ b/dnsapi/dns_dnsimple.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env sh
+
+# DNSimple domain api
+#
+# This is your oauth token which can be acquired on the account page. Please
+# note that this must be an _account_ token and not a _user_ token.
+# https://dnsimple.com/a/<your account id>/account/access_tokens
+# DNSimple_OAUTH_TOKEN="sdfsdfsdfljlbjkljlkjsdfoiwje"
+
+DNSimple_API="https://api.dnsimple.com/v2"
+
+########  Public functions #####################
+
+# Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_dnsimple_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  if [ -z "$DNSimple_OAUTH_TOKEN" ]; then
+    DNSimple_OAUTH_TOKEN=""
+    _err "You have not set the dnsimple oauth token yet."
+    _err "Please visit https://dnsimple.com/user to generate it."
+    return 1
+  fi
+
+  # save the oauth token for later
+  _saveaccountconf DNSimple_OAUTH_TOKEN "$DNSimple_OAUTH_TOKEN"
+
+  _debug "Retrive account ID"
+  if ! _get_account_id; then
+    _err "failed to retrive account id"
+    return 1
+  fi
+  _debug _account_id "$_account_id"
+
+  if ! _get_root "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+  _debug _domain "$_domain"
+  _debug _sub_domain "$_sub_domain"
+
+  _debug "Getting txt records"
+  _dnsimple_rest GET "$_account_id/zones/$_domain/records?per_page=100"
+
+  if ! _contains "$response" "\"id\":"; then
+    _err "Error"
+    return 1
+  fi
+
+  count=$(printf "%s" "$response" | _egrep_o "\"name\":\"$_sub_domain\"" | wc -l | _egrep_o "[0-9]+")
+  _debug count "$count"
+
+  if [ "$count" = "0" ]; then
+    _info "Adding record"
+    if _dnsimple_rest POST "$_account_id/zones/$_domain/records" "{\"type\":\"TXT\",\"name\":\"$_sub_domain\",\"content\":\"$txtvalue\",\"ttl\":120}"; then
+      if printf -- "%s" "$response" | grep "\"name\":\"$_sub_domain\"" >/dev/null; then
+        _info "Added"
+        return 0
+      else
+        _err "Add txt record error."
+        return 1
+      fi
+    fi
+    _err "Add txt record error."
+  else
+    _info "Updating record"
+    record_id=$(printf "%s" "$response" | _egrep_o "\"id\":[^,]*,\"zone_id\":\"[^,]*\",\"parent_id\":null,\"name\":\"$_sub_domain\"" | cut -d: -f2 | cut -d, -f1)
+    _debug "record_id" "$record_id"
+
+    _dnsimple_rest PATCH "$_account_id/zones/$_domain/records/$record_id" "{\"type\":\"TXT\",\"name\":\"$_sub_domain\",\"content\":\"$txtvalue\",\"ttl\":120}"
+    if [ "$?" = "0" ]; then
+      _info "Updated!"
+      #todo: check if the record takes effect
+      return 0
+    fi
+    _err "Update error"
+    return 1
+  fi
+}
+
+# fulldomain
+dns_dnsimple_rm() {
+  fulldomain=$1
+
+}
+
+####################  Private functions bellow ##################################
+# _acme-challenge.www.domain.com
+# returns
+#   _sub_domain=_acme-challenge.www
+#   _domain=domain.com
+_get_root() {
+  domain=$1
+  i=2
+  p=1
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
+    if [ -z "$h" ]; then
+      # not valid
+      return 1
+    fi
+
+    if ! _dnsimple_rest GET "$_account_id/zones/$h"; then
+      return 1
+    fi
+
+    if _contains "$response" 'not found'; then
+      _debug "$h not found"
+    else
+      _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
+      _domain="$h"
+      return 0
+    fi
+    p="$i"
+    i=$(_math "$i" + 1)
+  done
+  return 1
+}
+
+_get_account_id() {
+  if ! _dnsimple_rest GET "whoami"; then
+    return 1
+  fi
+
+  if _contains "$response" "\"account\":null"; then
+    _err "no account associated with this token"
+    return 1
+  fi
+
+  if _contains "$response" "timeout"; then
+    _err "timeout retrieving account_id"
+    return 1
+  fi
+
+  _account_id=$(printf "%s" "$response" | _egrep_o "\"id\":[^,]*,\"email\":" | cut -d: -f2 | cut -d, -f1)
+  return 0
+}
+
+_dnsimple_rest() {
+  method=$1
+  path="$2"
+  data="$3"
+  request_url="$DNSimple_API/$path"
+  _debug "$path"
+
+  _H1="Accept: application/json"
+  _H2="Authorization: Bearer $DNSimple_OAUTH_TOKEN"
+  if [ "$data" ]; then
+    _H1="Content-Type: application/json"
+    _debug data "$data"
+    response="$(_post "$data" "$request_url" "" "$method")"
+  else
+    response="$(_get "$request_url")"
+  fi
+
+  if [ "$?" != "0" ]; then
+    _err "error $request_url"
+    return 1
+  fi
+  _debug2 response "$response"
+  return 0
+}


### PR DESCRIPTION
Even though DNSimple is technically covered with lexicon not all systems can install python pip's easily. For these systems it is useful to have pure shell script API interactions.