### PR TITLE
Fall back to python if OpenSSL does not support '-macopt'

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -470,10 +470,10 @@ _hmac() {
       fi
     else
       # Try to fall back to python's built-in hmac/hashlib modules
-       [ -n "$outputhex" ] && outputhex=hex
+      [ -n "$outputhex" ] && outputhex=hex
       python -u -c \
-          'import sys,binascii,hmac,hashlib;sys.stdout.write(getattr(hmac.new(binascii.unhexlify(sys.argv[3]),sys.stdin.read(),getattr(hashlib,sys.argv[1])),sys.argv[2])())' \
-          "$alg" "${outputhex}digest" "$secret_hex"
+        'import sys,binascii,hmac,hashlib;sys.stdout.write(getattr(hmac.new(binascii.unhexlify(sys.argv[3]),sys.stdin.read(),getattr(hashlib,sys.argv[1])),sys.argv[2])())' \
+        "$alg" "${outputhex}digest" "$secret_hex"
     fi
   else
     _err "$alg is not supported yet"


### PR DESCRIPTION
This allows the script to work with the tools shipped with OS X.

The AWS DNS plugin in particular requires HMAC operations with binary keys, because the output form one HMAC becomes the key for the next round.

(The uses of HMAC in dns_ali and dns_me could be rewritten to instead pass the key as plain text rather than hex, and thus work with OpenSSL 0.9, but this wouldn't work for dns_aws).