### PR TITLE
dnsapi/dns_lexicon.sh: shellcheck: fix 4 occurences of SC2021:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ~/shfmt -l -w -i 2 . ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git diff --exit-code && echo "shfmt OK" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -V ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -e SC2021,SC2126,SC2034 **/*.sh && echo "shellcheck OK" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -e SC2126,SC2034 **/*.sh && echo "shellcheck OK" ; fi
   - cd ..
   - git clone https://github.com/Neilpang/acmetest.git && cp -r acme.sh acmetest/ && cd acmetest
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$NGROK_TOKEN" ]]; then sudo NGROK_TOKEN="$NGROK_TOKEN" ./letest.sh ; fi

--- a/dnsapi/dns_lexicon.sh
+++ b/dnsapi/dns_lexicon.sh
@@ -30,7 +30,9 @@ dns_lexicon_add() {
   _savedomainconf PROVIDER "$PROVIDER"
   export PROVIDER
 
-  Lx_name=$(echo LEXICON_"${PROVIDER}"_USERNAME | tr '[a-z]' '[A-Z]')
+  # e.g. busybox-ash does not know [:upper:]
+  # shellcheck disable=SC2018,SC2019
+  Lx_name=$(echo LEXICON_"${PROVIDER}"_USERNAME | tr 'a-z' 'A-Z')
   Lx_name_v=$(eval echo \$"$Lx_name")
   _debug "$Lx_name" "$Lx_name_v"
   if [ "$Lx_name_v" ]; then
@@ -38,7 +40,8 @@ dns_lexicon_add() {
     eval export "$Lx_name"
   fi
 
-  Lx_token=$(echo LEXICON_"${PROVIDER}"_TOKEN | tr '[a-z]' '[A-Z]')
+  # shellcheck disable=SC2018,SC2019
+  Lx_token=$(echo LEXICON_"${PROVIDER}"_TOKEN | tr 'a-z' 'A-Z')
   Lx_token_v=$(eval echo \$"$Lx_token")
   _debug "$Lx_token" "$Lx_token_v"
   if [ "$Lx_token_v" ]; then
@@ -46,7 +49,8 @@ dns_lexicon_add() {
     eval export "$Lx_token"
   fi
 
-  Lx_password=$(echo LEXICON_"${PROVIDER}"_PASSWORD | tr '[a-z]' '[A-Z]')
+  # shellcheck disable=SC2018,SC2019
+  Lx_password=$(echo LEXICON_"${PROVIDER}"_PASSWORD | tr 'a-z' 'A-Z')
   Lx_password_v=$(eval echo \$"$Lx_password")
   _debug "$Lx_password" "$Lx_password_v"
   if [ "$Lx_password_v" ]; then
@@ -54,7 +58,8 @@ dns_lexicon_add() {
     eval export "$Lx_password"
   fi
 
-  Lx_domaintoken=$(echo LEXICON_"${PROVIDER}"_DOMAINTOKEN | tr '[a-z]' '[A-Z]')
+  # shellcheck disable=SC2018,SC2019
+  Lx_domaintoken=$(echo LEXICON_"${PROVIDER}"_DOMAINTOKEN | tr 'a-z' 'A-Z')
   Lx_domaintoken_v=$(eval echo \$"$Lx_domaintoken")
   _debug "$Lx_domaintoken" "$Lx_domaintoken_v"
   if [ "$Lx_domaintoken_v" ]; then


### PR DESCRIPTION
"Don't use [] around ranges in tr, it replaces literal square brackets."

this introduces another warning:
"Use '[:lower:]' to support accents and foreign alphabets."

This is more a style thingy because we really want to only catch A-Z.
work around this by using a shellcheck-directive and a comment
that the [:lower:] will not work with e.g. busybox-ash.

if we later really want to use [:lower:], we should use 'sed' for that.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->