### PR TITLE
dnsapi/dns_dp.sh: shellcheck: fix 1 occurence of SC2126

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ~/shfmt -l -w -i 2 . ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git diff --exit-code && echo "shfmt OK" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -V ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -e SC2126,SC2034 **/*.sh && echo "shellcheck OK" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -e SC2034 **/*.sh && echo "shellcheck OK" ; fi
   - cd ..
   - git clone https://github.com/Neilpang/acmetest.git && cp -r acme.sh acmetest/ && cd acmetest
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$NGROK_TOKEN" ]]; then sudo NGROK_TOKEN="$NGROK_TOKEN" ./letest.sh ; fi

--- a/dnsapi/dns_dp.sh
+++ b/dnsapi/dns_dp.sh
@@ -102,7 +102,7 @@ existing_records() {
   fi
 
   if _contains "$response" "Action completed successful"; then
-    count=$(printf "%s" "$response" | grep '<type>TXT</type>' | wc -l | tr -d ' ')
+    count=$(printf "%s" "$response" | grep -c '<type>TXT</type>' | tr -d ' ')
     record_id=$(printf "%s" "$response" | grep '^<id>' | tail -1 | cut -d '>' -f 2 | cut -d '<' -f 1)
     _debug record_id "$record_id"
     return 0


### PR DESCRIPTION
shellcheck message was:
"Consider using grep -c instead of grep | wc"

Signed-off-by: Bastian Bittorf <bb@npl.de>