### PR TITLE
shellcheck: fix several occurences of SC2034

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ~/shfmt -l -w -i 2 . ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git diff --exit-code && echo "shfmt OK" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -V ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -e SC2034 **/*.sh && echo "shellcheck OK" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck **/*.sh && echo "shellcheck OK" ; fi
   - cd ..
   - git clone https://github.com/Neilpang/acmetest.git && cp -r acme.sh acmetest/ && cd acmetest
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$NGROK_TOKEN" ]]; then sudo NGROK_TOKEN="$NGROK_TOKEN" ./letest.sh ; fi

--- a/dnsapi/dns_ad.sh
+++ b/dnsapi/dns_ad.sh
@@ -127,8 +127,8 @@ _ad_rest() {
   _debug mtd "$mtd"
   _debug ep "$ep"
 
-  _H1="Accept: application/json"
-  _H2="Content-Type: application/json"
+  export _H1="Accept: application/json"
+  export _H2="Content-Type: application/json"
 
   if [ "$mtd" != "GET" ]; then
     # both POST and DELETE.

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -137,13 +137,13 @@ aws_rest() {
 
   #RequestDate="20161120T141056Z" ##############
 
-  _H1="x-amz-date: $RequestDate"
+  export _H1="x-amz-date: $RequestDate"
 
   aws_host="$AWS_HOST"
   CanonicalHeaders="host:$aws_host\nx-amz-date:$RequestDate\n"
   SignedHeaders="host;x-amz-date"
   if [ -n "$AWS_SESSION_TOKEN" ]; then
-    _H2="x-amz-security-token: $AWS_SESSION_TOKEN"
+    export _H2="x-amz-security-token: $AWS_SESSION_TOKEN"
     CanonicalHeaders="${CanonicalHeaders}x-amz-security-token:$AWS_SESSION_TOKEN\n"
     SignedHeaders="${SignedHeaders};x-amz-security-token"
   fi

--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -163,9 +163,9 @@ _cf_rest() {
   data="$3"
   _debug "$ep"
 
-  _H1="X-Auth-Email: $CF_Email"
-  _H2="X-Auth-Key: $CF_Key"
-  _H3="Content-Type: application/json"
+  export _H1="X-Auth-Email: $CF_Email"
+  export _H2="X-Auth-Key: $CF_Key"
+  export _H3="Content-Type: application/json"
 
   if [ "$m" != "GET" ]; then
     _debug data "$data"

--- a/dnsapi/dns_cx.sh
+++ b/dnsapi/dns_cx.sh
@@ -193,10 +193,10 @@ _rest() {
   hmac=$(printf "%s" "$sec" | _digest md5 hex)
   _debug hmac "$hmac"
 
-  _H1="API-KEY: $CX_Key"
-  _H2="API-REQUEST-DATE: $cdate"
-  _H3="API-HMAC: $hmac"
-  _H4="Content-Type: application/json"
+  export _H1="API-KEY: $CX_Key"
+  export _H2="API-REQUEST-DATE: $cdate"
+  export _H3="API-HMAC: $hmac"
+  export _H4="Content-Type: application/json"
 
   if [ "$data" ]; then
     response="$(_post "$data" "$url" "" "$m")"

--- a/dnsapi/dns_gd.sh
+++ b/dnsapi/dns_gd.sh
@@ -98,8 +98,8 @@ _gd_rest() {
   data="$3"
   _debug "$ep"
 
-  _H1="Authorization: sso-key $GD_Key:$GD_Secret"
-  _H2="Content-Type: application/json"
+  export _H1="Authorization: sso-key $GD_Key:$GD_Secret"
+  export _H2="Content-Type: application/json"
 
   if [ "$data" ]; then
     _debug data "$data"

--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -46,7 +46,7 @@ _ISPC_credentials() {
     _saveaccountconf ISPC_Api "${ISPC_Api}"
     _saveaccountconf ISPC_Api_Insecure "${ISPC_Api_Insecure}"
     # Set whether curl should use secure or insecure mode
-    HTTPS_INSECURE="${ISPC_Api_Insecure}"
+    export HTTPS_INSECURE="${ISPC_Api_Insecure}"
   fi
 }
 

--- a/dnsapi/dns_lexicon.sh
+++ b/dnsapi/dns_lexicon.sh
@@ -2,7 +2,7 @@
 
 # dns api wrapper of lexicon for acme.sh
 
-lexicon_url="https://github.com/AnalogJ/lexicon"
+# https://github.com/AnalogJ/lexicon
 lexicon_cmd="lexicon"
 
 wiki="https://github.com/Neilpang/acme.sh/wiki/How-to-use-lexicon-dns-api"

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -125,8 +125,8 @@ _LUA_rest() {
   data="$3"
   _debug "$ep"
 
-  _H1="Accept: application/json"
-  _H2="Authorization: Basic $LUA_auth"
+  export _H1="Accept: application/json"
+  export _H2="Authorization: Basic $LUA_auth"
   if [ "$data" ]; then
     _debug data "$data"
     response="$(_post "$data" "$LUA_Api/$ep" "" "$m")"

--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -126,9 +126,9 @@ _me_rest() {
   cdate=$(date -u +"%a, %d %b %Y %T %Z")
   hmac=$(printf "%s" "$cdate" | _hmac sha1 "$(_hex "$ME_Secret")" hex)
 
-  _H1="x-dnsme-apiKey: $ME_Key"
-  _H2="x-dnsme-requestDate: $cdate"
-  _H3="x-dnsme-hmac: $hmac"
+  export _H1="x-dnsme-apiKey: $ME_Key"
+  export _H2="x-dnsme-requestDate: $cdate"
+  export _H3="x-dnsme-hmac: $hmac"
 
   if [ "$data" ]; then
     _debug data "$data"

--- a/dnsapi/dns_ovh.sh
+++ b/dnsapi/dns_ovh.sh
@@ -273,12 +273,12 @@ _ovh_rest() {
   _ovh_hex="$(printf "%s" "$_ovh_p" | _digest sha1 hex)"
   _debug2 _ovh_hex "$_ovh_hex"
 
-  _H1="X-Ovh-Application: $OVH_AK"
-  _H2="X-Ovh-Signature: \$1\$$_ovh_hex"
+  export _H1="X-Ovh-Application: $OVH_AK"
+  export _H2="X-Ovh-Signature: \$1\$$_ovh_hex"
   _debug2 _H2 "$_H2"
-  _H3="X-Ovh-Timestamp: $_ovh_t"
-  _H4="X-Ovh-Consumer: $OVH_CK"
-  _H5="Content-Type: application/json;charset=utf-8"
+  export _H3="X-Ovh-Timestamp: $_ovh_t"
+  export _H4="X-Ovh-Consumer: $OVH_CK"
+  export _H5="Content-Type: application/json;charset=utf-8"
   if [ "$data" ] || [ "$m" = "POST" ] || [ "$m" = "PUT" ]; then
     _debug data "$data"
     response="$(_post "$data" "$_ovh_url" "" "$m")"

--- a/dnsapi/dns_pdns.sh
+++ b/dnsapi/dns_pdns.sh
@@ -165,7 +165,7 @@ _pdns_rest() {
   ep=$2
   data=$3
 
-  _H1="X-API-Key: $PDNS_Token"
+  export _H1="X-API-Key: $PDNS_Token"
 
   if [ ! "$method" = "GET" ]; then
     _debug data "$data"


### PR DESCRIPTION
message:
SC2034: $VARNAME appears unused. Verify it or export it.

most of these are related to the style:
we generate global vars, which are used in other functions.

the var "lexicon_url" was really unused (left it as comment)

the travis-check now enforces a POSIX-shell (dash).
this makes it now possible to use 'local var=foo' in functions.

Signed-off-by: Bastian Bittorf <bb@npl.de>

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->