### PR TITLE
--ca-path patch for curl/wget ssl support

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1479,7 +1479,9 @@ _inithttp() {
       _ACME_CURL="$_ACME_CURL --trace-ascii $_CURL_DUMP "
     fi
 
-    if [ "$CA_BUNDLE" ]; then
+    if [ "$CA_PATH" ]; then
+      _ACME_CURL="$_ACME_CURL --capath $CA_PATH "
+    elif [ "$CA_BUNDLE" ]; then
       _ACME_CURL="$_ACME_CURL --cacert $CA_BUNDLE "
     fi
 
@@ -1490,8 +1492,10 @@ _inithttp() {
     if [ "$DEBUG" ] && [ "$DEBUG" -ge "2" ]; then
       _ACME_WGET="$_ACME_WGET -d "
     fi
-    if [ "$CA_BUNDLE" ]; then
-      _ACME_WGET="$_ACME_WGET --ca-certificate $CA_BUNDLE "
+    if [ "$CA_PATH" ]; then
+      _ACME_WGET="$_ACME_WGET --ca-directory=$CA_PATH "
+    elif [ "$CA_BUNDLE" ]; then
+      _ACME_WGET="$_ACME_WGET --ca-certificate=$CA_BUNDLE "
     fi
   fi
 
@@ -3702,6 +3706,12 @@ issue() {
   else
     _clearaccountconf "CA_BUNDLE"
   fi
+  
+  if [ "$CA_PATH" ]; then
+    _saveaccountconf CA_PATH "$CA_PATH"
+  else
+    _clearaccountconf "CA_PATH"
+  fi
 
   if [ "$HTTPS_INSECURE" ]; then
     _saveaccountconf HTTPS_INSECURE "$HTTPS_INSECURE"
@@ -4918,6 +4928,7 @@ _process() {
   _stopRenewOnError=""
   #_insecure=""
   _ca_bundle=""
+  _ca_path=""
   _nocron=""
   _ecc=""
   _csr=""
@@ -5230,6 +5241,11 @@ _process() {
       --ca-bundle)
         _ca_bundle="$(_readlink -f "$2")"
         CA_BUNDLE="$_ca_bundle"
+        shift
+        ;;
+      --ca-path)
+        _ca_path="$2"
+        CA_PATH="$_ca_path"
         shift
         ;;
       --nocron)

--- a/acme.sh
+++ b/acme.sh
@@ -3706,7 +3706,7 @@ issue() {
   else
     _clearaccountconf "CA_BUNDLE"
   fi
-  
+
   if [ "$CA_PATH" ]; then
     _saveaccountconf CA_PATH "$CA_PATH"
   else


### PR DESCRIPTION
Add --ca-path option for providing trusted certs, needed to support DD-WRT. #731 