### PR TITLE
Update dns_aws.sh to work only with public zones

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -106,7 +106,7 @@ _get_root() {
       fi
 
       if _contains "$response" "<Name>$h.</Name>"; then
-        hostedzone="$(echo "$response" | sed 's/<HostedZone>/#&/g' | tr '#' '\n' | _egrep_o "<HostedZone><Id>[^<]*<.Id><Name>$h.<.Name>.*<.HostedZone>")"
+        hostedzone="$(echo "$response" | sed 's/<HostedZone>/#&/g' | tr '#' '\n' | _egrep_o "<HostedZone><Id>[^<]*<.Id><Name>$h.<.Name>.*<PrivateZone>false<.PrivateZone>.*<.HostedZone>")"
         _debug hostedzone "$hostedzone"
         if [ -z "$hostedzone" ]; then
           _err "Error, can not get hostedzone."


### PR DESCRIPTION
Update dns_aws.sh to work only with public zones.
Workflow: private and public zone with same name (split DNS).
Now it's determine only Public zone