### PR TITLE
Support OVH credentials scoped to a specific zone

### DIFF
--- a/dnsapi/dns_ovh.sh
+++ b/dnsapi/dns_ovh.sh
@@ -238,7 +238,7 @@ _get_root() {
       return 1
     fi
 
-    if ! _contains "$response" "This service does not exist" >/dev/null; then
+    if ! _contains "$response" "This service does not exist" >/dev/null && ! _contains "$response" "NOT_GRANTED_CALL" >/dev/null; then
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
       _domain="$h"
       return 0


### PR DESCRIPTION
When creating OVH API credentials, one can scope them to a specific subset of routes. Specifically, this allows to limit acme.sh to a specific zone as the zone is part of the URL. This is an important security/safety net feature.

If that's good for you, I plan to update the wiki page wo explain how to create scoped credentials in one shot (with no url to visit for validation)