### PR TITLE
Add support for deploying to cpanel using perl

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4640,6 +4640,11 @@ install() {
     return 1
   fi
 
+  if [ -z "$_c_home" ] && [ "$LE_CONFIG_HOME" != "$LE_WORKING_DIR" ]; then
+    _info "Using config home: $LE_CONFIG_HOME"
+    _c_home="$LE_CONFIG_HOME"
+  fi
+
   #convert from le
   if [ -d "$HOME/.le" ]; then
     for envfile in "le.env" "le.sh.env"; do

--- a/deploy/cpanel.sh
+++ b/deploy/cpanel.sh
@@ -25,113 +25,62 @@ cpanel_deploy() {
   _debug _cfullchain "$_cfullchain"
 
 export _ckey _ccert _cdomain
-# Perl code taken from https://documentation.cpanel.net/display/SDK/Tutorial+-+Call+UAPI%27s+SSL%3A%3Ainstall_ssl+Function+in+Custom+Code
-perl -f <<'END'
-# Return errors if Perl experiences problems.
-use strict;
-use warnings;
-# Allow my code to perform web requests.
-use LWP::UserAgent;
-use LWP::Protocol::https;
-# Use the correct encoding to prevent wide character warnings.
-use Encode;
-use utf8;
-# Properly decode JSON.
-use JSON;
-# Function properly with Base64 authentication headers.
-use MIME::Base64;
+# PHP code taken from https://documentation.cpanel.net/display/DD/Tutorial+-+Call+UAPI's+SSL::install_ssl+Function+in+Custom+Code
+php <<'END'
+<?php
+// Log everything during development.
+// If you run this on the CLI, set 'display_errors = On' in php.ini.
+error_reporting(E_ALL);
 
-# Authentication information.
-my $username = $ENV{'DEPLOY_CPANEL_USER'};
-my $password = $ENV{'DEPLOY_CPANEL_PASSWORD'};
-my $hostname = $ENV{'DEPLOY_CPANEL_HOSTNAME'};
+// Authentication information.
+$username = getenv('DEPLOY_CPANEL_USER');
+$password = getenv('DEPLOY_CPANEL_PASSWORD');
+$hostname = getenv('DEPLOY_CPANEL_HOSTNAME');
 
-# The URL for the SSL::install_ssl UAPI function.
-my $request = "https://".$hostname."/execute/SSL/install_ssl";
+// The URL for the SSL::install_ssl UAPI function.
+$request = "https://".$hostname."/execute/SSL/install_ssl";
 
-# Required to allow HTTPS connections to unsigned services.
-# Services on localhost are always unsigned.
-$ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
+// Read in the SSL certificate and key file.
+$cert = getenv('_ccert');
+$key = getenv('_ckey');
 
-# Create a useragent object.
-my $ua = LWP::UserAgent->new();
-
-# Add authentication headers.
-$ua->default_header(
-    'Authorization' => 'Basic ' . MIME::Base64::encode("$username:$password"),
+// Set up the payload to send to the server.
+$domain = getenv('_cdomain');
+$payload = array(
+    'domain' => "$domain",
+    'cert'   => file_get_contents($cert),
+    'key'    => file_get_contents($key)
 );
 
-# Read in the SSL certificate and key file.
-my $cert = $ENV{'_ccert'};
-my $key = $ENV{'_ckey'};
-{
-    local $/;
-    open ( my $fh, '<', $cert );
-    $cert = <$fh>;
-    close $fh;
+// Set up the cURL request object.
+$ch = curl_init( $request );
+curl_setopt( $ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC );
+curl_setopt( $ch, CURLOPT_USERPWD, $username . ':' . $password );
+curl_setopt( $ch, CURLOPT_SSL_VERIFYHOST, false );
+curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
 
-    open ( $fh, '<', $key );
-    $key = <$fh>;
-    close $fh;
+// Set up a POST request with the payload.
+curl_setopt( $ch, CURLOPT_POST, true );
+curl_setopt( $ch, CURLOPT_POSTFIELDS, $payload );
+curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+
+// Make the call, and then terminate the cURL caller object.
+$curl_response = curl_exec( $ch );
+curl_close( $ch );
+
+// Decode and validate output.
+$response = json_decode( $curl_response );
+if( empty( $response ) ) {
+    echo "The cURL call did not return valid JSON:\n";
+    die( $response );
+} elseif ( !$response->status ) {
+    echo "The cURL call returned valid JSON, but reported errors:\n";
+    die( $response->errors[0] . "\n" );
 }
 
-my $domain = $ENV{'_cdomain'};
-
-# Make the call.
-my $response = $ua->post($request,
-    Content_Type => 'form-data',
-    Content => [
-        domain => $domain,
-        cert   => $cert,
-        key    => $key,
-    ],
-);
-
-# Create an object to decode the JSON.
-# Sorted by keys and pretty-printed.
-my $json_printer = JSON->new->pretty->canonical(1);
-
-# UTF-8 encode before decoding to avoid wide character warnings.
-my $content = JSON::decode_json(Encode::encode_utf8($response->decoded_content));
-
-# Print output, UTF-8 encoded to avoid wide character warnings.
-print Encode::encode_utf8($json_printer->encode($content));
-
-=pod
-{
-   "data" : {
-      "action" : "none",
-      "aliases" : [
-         "mail.example.com"
-      ],
-      "cert_id" : "example_com_xxx_yyy_zzzzzzzzzzzzzzzzzz",
-      "domain" : "example.com",
-      "extra_certificate_domains" : [],
-      "html" : "<br /><b>This certificate was already installed on this host. The system made no changes.</b><br />\n",
-      "ip" : "127.0.0.1",
-      "key_id" : "xxx_yyy_zzzzzzzzzzzzzzzz",
-      "message" : "This certificate was already installed on this host. The system made no changes.",
-      "servername" : "example.com",
-      "status" : 1,
-      "statusmsg" : "This certificate was already installed on this host. The system made no changes.",
-      "user" : "username",
-      "warning_domains" : [
-         "mail.example.com"
-      ],
-      "working_domains" : [
-         "example.com"
-      ]
-   },
-   "errors" : null,
-   "messages" : [
-      "The certificate was successfully installed on the domain “example.com”."
-   ],
-   "metadata" : {},
-   "status" : 1
-}
-=cut
+// Print and exit.
+die( print_r( $response ) );
 
 END
 
 }
-

--- a/deploy/cpanel.sh
+++ b/deploy/cpanel.sh
@@ -6,6 +6,7 @@
 
 #export DEPLOY_CPANEL_USER=myusername
 #export DEPLOY_CPANEL_PASSWORD=PASSWORD
+#export DEPLOY_CPANEL_HOSTNAME=localhost:2083
 
 ########  Public functions #####################
 
@@ -23,7 +24,114 @@ cpanel_deploy() {
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"
 
-  _err "Not implemented yet"
-  return 1
+export _ckey _ccert _cdomain
+# Perl code taken from https://documentation.cpanel.net/display/SDK/Tutorial+-+Call+UAPI%27s+SSL%3A%3Ainstall_ssl+Function+in+Custom+Code
+perl -f <<'END'
+# Return errors if Perl experiences problems.
+use strict;
+use warnings;
+# Allow my code to perform web requests.
+use LWP::UserAgent;
+use LWP::Protocol::https;
+# Use the correct encoding to prevent wide character warnings.
+use Encode;
+use utf8;
+# Properly decode JSON.
+use JSON;
+# Function properly with Base64 authentication headers.
+use MIME::Base64;
+
+# Authentication information.
+my $username = $ENV{'DEPLOY_CPANEL_USER'};
+my $password = $ENV{'DEPLOY_CPANEL_PASSWORD'};
+my $hostname = $ENV{'DEPLOY_CPANEL_HOSTNAME'};
+
+# The URL for the SSL::install_ssl UAPI function.
+my $request = "https://".$hostname."/execute/SSL/install_ssl";
+
+# Required to allow HTTPS connections to unsigned services.
+# Services on localhost are always unsigned.
+$ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
+
+# Create a useragent object.
+my $ua = LWP::UserAgent->new();
+
+# Add authentication headers.
+$ua->default_header(
+    'Authorization' => 'Basic ' . MIME::Base64::encode("$username:$password"),
+);
+
+# Read in the SSL certificate and key file.
+my $cert = $ENV{'_ccert'};
+my $key = $ENV{'_ckey'};
+{
+    local $/;
+    open ( my $fh, '<', $cert );
+    $cert = <$fh>;
+    close $fh;
+
+    open ( $fh, '<', $key );
+    $key = <$fh>;
+    close $fh;
+}
+
+my $domain = $ENV{'_cdomain'};
+
+# Make the call.
+my $response = $ua->post($request,
+    Content_Type => 'form-data',
+    Content => [
+        domain => $domain,
+        cert   => $cert,
+        key    => $key,
+    ],
+);
+
+# Create an object to decode the JSON.
+# Sorted by keys and pretty-printed.
+my $json_printer = JSON->new->pretty->canonical(1);
+
+# UTF-8 encode before decoding to avoid wide character warnings.
+my $content = JSON::decode_json(Encode::encode_utf8($response->decoded_content));
+
+# Print output, UTF-8 encoded to avoid wide character warnings.
+print Encode::encode_utf8($json_printer->encode($content));
+
+=pod
+{
+   "data" : {
+      "action" : "none",
+      "aliases" : [
+         "mail.example.com"
+      ],
+      "cert_id" : "example_com_xxx_yyy_zzzzzzzzzzzzzzzzzz",
+      "domain" : "example.com",
+      "extra_certificate_domains" : [],
+      "html" : "<br /><b>This certificate was already installed on this host. The system made no changes.</b><br />\n",
+      "ip" : "127.0.0.1",
+      "key_id" : "xxx_yyy_zzzzzzzzzzzzzzzz",
+      "message" : "This certificate was already installed on this host. The system made no changes.",
+      "servername" : "example.com",
+      "status" : 1,
+      "statusmsg" : "This certificate was already installed on this host. The system made no changes.",
+      "user" : "username",
+      "warning_domains" : [
+         "mail.example.com"
+      ],
+      "working_domains" : [
+         "example.com"
+      ]
+   },
+   "errors" : null,
+   "messages" : [
+      "The certificate was successfully installed on the domain “example.com”."
+   ],
+   "metadata" : {},
+   "status" : 1
+}
+=cut
+
+END
 
 }
+

--- a/deploy/cpanel.sh
+++ b/deploy/cpanel.sh
@@ -25,113 +25,62 @@ cpanel_deploy() {
   _debug _cfullchain "$_cfullchain"
 
 export _ckey _ccert _cdomain
-# Perl code taken from https://documentation.cpanel.net/display/SDK/Tutorial+-+Call+UAPI%27s+SSL%3A%3Ainstall_ssl+Function+in+Custom+Code
-perl -f <<'END'
-# Return errors if Perl experiences problems.
-use strict;
-use warnings;
-# Allow my code to perform web requests.
-use LWP::UserAgent;
-use LWP::Protocol::https;
-# Use the correct encoding to prevent wide character warnings.
-use Encode;
-use utf8;
-# Properly decode JSON.
-use JSON;
-# Function properly with Base64 authentication headers.
-use MIME::Base64;
+# PHP code taken from https://documentation.cpanel.net/display/DD/Tutorial+-+Call+UAPI's+SSL::install_ssl+Function+in+Custom+Code
+php <<'END'
+<?php
+// Log everything during development.
+// If you run this on the CLI, set 'display_errors = On' in php.ini.
+error_reporting(E_ALL);
 
-# Authentication information.
-my $username = $ENV{'DEPLOY_CPANEL_USER'};
-my $password = $ENV{'DEPLOY_CPANEL_PASSWORD'};
-my $hostname = $ENV{'DEPLOY_CPANEL_HOSTNAME'};
+// Authentication information.
+$username = getenv('DEPLOY_CPANEL_USER');
+$password = getenv('DEPLOY_CPANEL_PASSWORD');
 
-# The URL for the SSL::install_ssl UAPI function.
-my $request = "https://".$hostname."/execute/SSL/install_ssl";
+// The URL for the SSL::install_ssl UAPI function.
+$request = "https://cpanel61.fastdnsservers.com:2083/execute/SSL/install_ssl";
+$request = "https://localhost:2083/execute/SSL/install_ssl";
 
-# Required to allow HTTPS connections to unsigned services.
-# Services on localhost are always unsigned.
-$ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
+// Read in the SSL certificate and key file.
+$cert = getenv('_ccert');
+$key = getenv('_ckey');
 
-# Create a useragent object.
-my $ua = LWP::UserAgent->new();
-
-# Add authentication headers.
-$ua->default_header(
-    'Authorization' => 'Basic ' . MIME::Base64::encode("$username:$password"),
+// Set up the payload to send to the server.
+$domain = getenv('_cdomain');
+$payload = array(
+    'domain' => "$domain",
+    'cert'   => file_get_contents($cert),
+    'key'    => file_get_contents($key)
 );
 
-# Read in the SSL certificate and key file.
-my $cert = $ENV{'_ccert'};
-my $key = $ENV{'_ckey'};
-{
-    local $/;
-    open ( my $fh, '<', $cert );
-    $cert = <$fh>;
-    close $fh;
+// Set up the cURL request object.
+$ch = curl_init( $request );
+curl_setopt( $ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC );
+curl_setopt( $ch, CURLOPT_USERPWD, $username . ':' . $password );
+curl_setopt( $ch, CURLOPT_SSL_VERIFYHOST, false );
+curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
 
-    open ( $fh, '<', $key );
-    $key = <$fh>;
-    close $fh;
+// Set up a POST request with the payload.
+curl_setopt( $ch, CURLOPT_POST, true );
+curl_setopt( $ch, CURLOPT_POSTFIELDS, $payload );
+curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+
+// Make the call, and then terminate the cURL caller object.
+$curl_response = curl_exec( $ch );
+curl_close( $ch );
+
+// Decode and validate output.
+$response = json_decode( $curl_response );
+if( empty( $response ) ) {
+    echo "The cURL call did not return valid JSON:\n";
+    die( $response );
+} elseif ( !$response->status ) {
+    echo "The cURL call returned valid JSON, but reported errors:\n";
+    die( $response->errors[0] . "\n" );
 }
 
-my $domain = $ENV{'_cdomain'};
-
-# Make the call.
-my $response = $ua->post($request,
-    Content_Type => 'form-data',
-    Content => [
-        domain => $domain,
-        cert   => $cert,
-        key    => $key,
-    ],
-);
-
-# Create an object to decode the JSON.
-# Sorted by keys and pretty-printed.
-my $json_printer = JSON->new->pretty->canonical(1);
-
-# UTF-8 encode before decoding to avoid wide character warnings.
-my $content = JSON::decode_json(Encode::encode_utf8($response->decoded_content));
-
-# Print output, UTF-8 encoded to avoid wide character warnings.
-print Encode::encode_utf8($json_printer->encode($content));
-
-=pod
-{
-   "data" : {
-      "action" : "none",
-      "aliases" : [
-         "mail.example.com"
-      ],
-      "cert_id" : "example_com_xxx_yyy_zzzzzzzzzzzzzzzzzz",
-      "domain" : "example.com",
-      "extra_certificate_domains" : [],
-      "html" : "<br /><b>This certificate was already installed on this host. The system made no changes.</b><br />\n",
-      "ip" : "127.0.0.1",
-      "key_id" : "xxx_yyy_zzzzzzzzzzzzzzzz",
-      "message" : "This certificate was already installed on this host. The system made no changes.",
-      "servername" : "example.com",
-      "status" : 1,
-      "statusmsg" : "This certificate was already installed on this host. The system made no changes.",
-      "user" : "username",
-      "warning_domains" : [
-         "mail.example.com"
-      ],
-      "working_domains" : [
-         "example.com"
-      ]
-   },
-   "errors" : null,
-   "messages" : [
-      "The certificate was successfully installed on the domain “example.com”."
-   ],
-   "metadata" : {},
-   "status" : 1
-}
-=cut
+// Print and exit.
+die( print_r( $response ) );
 
 END
 
 }
-


### PR DESCRIPTION
Found that deploying to cpanel didn't work. Found a tutorial to deploy ssl to cpanel via API calls. Filled in the blanks and verified on my web host.

No error checks, but it prints out the result as as JSON dump, making errors hopefully obvious if run manually.

I had to use a fqdn rather than localhost to access my cpanel so I made it another variable.

The real trick will be seeing if I can get this to automate in 60 days when my cert updates itself :)