### PR TITLE
remove colored output at least for TERMs starting with "vt"

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -102,6 +102,10 @@ __INTERACTIVE=""
 if [ -t 1 ]; then
   __INTERACTIVE="1"
 fi
+if [[ "$TERM" =~ "^vt" ]]
+then
+  unset __INTERACTIVE
+fi
 
 __green() {
   if [ "$__INTERACTIVE" ]; then


### PR DESCRIPTION
On ANY interactive shell the output is colored regardless of the terminal (emulation) is color capable or not.
This patch disables colored output at least for TERMs starting with "vt" (e.g. vt100, vt52).
