### PR TITLE
Cleanup Cloudflare dns_cf.sh for general consistency, keeping changes…

### DIFF
--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env sh
-
 #
-#CF_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
+# Cloudflare.com API
+# https://api.cloudflare.com/
 #
-#CF_Email="xxxx@sss.com"
+# Pass credentials before "acme.sh --issue --dns dns_cf ..."
+# --
+# export CF_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
+# export CF_Email="xxxx@sss.com"
+# --
 
-CF_Api="https://api.cloudflare.com/client/v4"
+CF_API="https://api.cloudflare.com/client/v4"
 
 ########  Public functions #####################
 
 #Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_cf_add() {
-  fulldomain=$1
-  txtvalue=$2
+  fulldomain="$1"
+  txtvalue="$2"
 
   CF_Key="${CF_Key:-$(_readaccountconf_mutable CF_Key)}"
   CF_Email="${CF_Email:-$(_readaccountconf_mutable CF_Email)}"
@@ -35,56 +39,50 @@ dns_cf_add() {
   _saveaccountconf_mutable CF_Email "$CF_Email"
 
   _debug "First detect the root zone"
-  if ! _get_root "$fulldomain"; then
-    _err "invalid domain"
+  if ! _cf_get_zone; then
     return 1
   fi
-  _debug _domain_id "$_domain_id"
-  _debug _sub_domain "$_sub_domain"
-  _debug _domain "$_domain"
+  _debug _cf_zone "$_cf_zone"
+  _debug _cf_zone_id "$_cf_zone_id"
 
-  _debug "Getting txt records"
-  _cf_rest GET "zones/${_domain_id}/dns_records?type=TXT&name=$fulldomain"
+  _debug "Getting TXT records"
+  _cf_rest GET "zones/$_cf_zone_id/dns_records?type=TXT&name=$fulldomain"
 
-  if ! printf "%s" "$response" | grep \"success\":true >/dev/null; then
-    _err "Error"
+  if ! _contains "$response" '"success":true'; then
+    _err "Error getting TXT records"
     return 1
   fi
 
-  count=$(printf "%s\n" "$response" | _egrep_o "\"count\":[^,]*" | cut -d : -f 2)
+  count="$(printf "%s\n" "$response" | _egrep_o '"count" *: *[^,]*' | _head_n 1 | sed 's#^"count" *: *##')"
   _debug count "$count"
   if [ "$count" = "0" ]; then
     _info "Adding record"
-    if _cf_rest POST "zones/$_domain_id/dns_records" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":120}"; then
-      if printf -- "%s" "$response" | grep "$fulldomain" >/dev/null; then
+    if _cf_rest POST "zones/$_cf_zone_id/dns_records" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":120}"; then
+      if _contains "$response" "$fulldomain"; then
         _info "Added, OK"
         return 0
-      else
-        _err "Add txt record error."
-        return 1
       fi
     fi
-    _err "Add txt record error."
+    _err "Add TXT record error."
   else
     _info "Updating record"
-    record_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | head -n 1)
-    _debug "record_id" "$record_id"
+    record_id="$(printf "%s\n" "$response" | _egrep_o '"id" *: *"[^"]*' | _head_n 1 | sed 's#^"id" *: *"##')"
+    _debug record_id "$record_id"
 
-    _cf_rest PUT "zones/$_domain_id/dns_records/$record_id" "{\"id\":\"$record_id\",\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"zone_id\":\"$_domain_id\",\"zone_name\":\"$_domain\"}"
-    if [ "$?" = "0" ]; then
+    if _cf_rest PUT "zones/$_cf_zone_id/dns_records/$record_id" "{\"id\":\"$record_id\",\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"zone_id\":\"$_cf_zone_id\",\"zone_name\":\"$_cf_zone\"}"; then
       _info "Updated, OK"
       return 0
     fi
-    _err "Update error"
-    return 1
+    _err "Update TXT record error"
   fi
 
+  return 1
 }
 
 #fulldomain txtvalue
 dns_cf_rm() {
-  fulldomain=$1
-  txtvalue=$2
+  fulldomain="$1"
+  txtvalue="$2"
 
   CF_Key="${CF_Key:-$(_readaccountconf_mutable CF_Key)}"
   CF_Email="${CF_Email:-$(_readaccountconf_mutable CF_Email)}"
@@ -97,100 +95,103 @@ dns_cf_rm() {
   fi
 
   _debug "First detect the root zone"
-  if ! _get_root "$fulldomain"; then
-    _err "invalid domain"
+  if ! _cf_get_zone; then
     return 1
   fi
-  _debug _domain_id "$_domain_id"
-  _debug _sub_domain "$_sub_domain"
-  _debug _domain "$_domain"
+  _debug _cf_zone "$_cf_zone"
+  _debug _cf_zone_id "$_cf_zone_id"
 
-  _debug "Getting txt records"
-  _cf_rest GET "zones/${_domain_id}/dns_records?type=TXT&name=$fulldomain&content=$txtvalue"
+  _debug "Getting TXT records"
+  _cf_rest GET "zones/$_cf_zone_id/dns_records?type=TXT&name=$fulldomain&content=$txtvalue"
 
-  if ! printf "%s" "$response" | grep \"success\":true >/dev/null; then
-    _err "Error"
+  if ! _contains "$response" '"success":true'; then
+    _err "Error getting TXT records"
     return 1
   fi
 
-  count=$(printf "%s\n" "$response" | _egrep_o "\"count\":[^,]*" | cut -d : -f 2)
+  count="$(printf "%s\n" "$response" | _egrep_o '"count" *: *[^,]*' | _head_n 1 | sed 's#^"count" *: *##')"
   _debug count "$count"
   if [ "$count" = "0" ]; then
     _info "Don't need to remove."
-  else
-    record_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | head -n 1)
-    _debug "record_id" "$record_id"
-    if [ -z "$record_id" ]; then
-      _err "Can not get record id to remove."
-      return 1
-    fi
-    if ! _cf_rest DELETE "zones/$_domain_id/dns_records/$record_id"; then
-      _err "Delete record error."
-      return 1
-    fi
-    _contains "$response" '"success":true'
+    return 0
   fi
 
+  record_id="$(printf "%s\n" "$response" | _egrep_o '"id" *: *"[^"]*' | _head_n 1 | sed 's#^"id" *: *"##')"
+  _debug record_id "$record_id"
+  if [ -z "$record_id" ]; then
+    _err "Can not get record id to remove."
+    return 1
+  fi
+
+  if _cf_rest DELETE "zones/$_cf_zone_id/dns_records/$record_id"; then
+    if _contains "$response" '"success":true'; then
+      return 0
+    fi
+  fi
+  _err "Delete record error."
+
+  return 1
 }
 
 ####################  Private functions below ##################################
-#_acme-challenge.www.domain.com
+#fulldomain=_acme-challenge.www.domain.com
 #returns
-# _sub_domain=_acme-challenge.www
-# _domain=domain.com
-# _domain_id=sdjkglgdfewsdfg
-_get_root() {
-  domain=$1
+# _cf_zone=domain.com
+# _cf_zone_id=sdjkglgdfewsdfg
+_cf_get_zone() {
   i=2
-  p=1
   while true; do
-    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
-    _debug h "$h"
-    if [ -z "$h" ]; then
-      #not valid
-      return 1
+    domain="$(printf "%s" "$fulldomain" | cut -d . -f "$i-100")"
+    if [ -z "$domain" ]; then
+      break
     fi
 
-    if ! _cf_rest GET "zones?name=$h"; then
-      return 1
+    if ! _cf_rest GET "zones?name=$domain"; then
+      break
     fi
 
-    if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
-      _domain_id=$(printf "%s\n" "$response" | _egrep_o "\[.\"id\":\"[^\"]*\"" | head -n 1 | cut -d : -f 2 | tr -d \")
-      if [ "$_domain_id" ]; then
-        _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
-        _domain=$h
-        return 0
+    _debug domain "$domain"
+
+    if _contains "$response" "\"name\":\"$domain\""; then
+      _cf_zone_id="$(printf "%s\n" "$response" | _egrep_o '\[."id" *: *"[^"]*' | _head_n 1 | sed 's#^\[."id" *: *"##')"
+      if [ -z "$_cf_zone_id" ]; then
+        break
       fi
-      return 1
+      _cf_zone="$domain"
+      return 0
     fi
-    p=$i
     i=$(_math "$i" + 1)
   done
+
+  _cf_zone=""
+  _cf_zone_id=""
+  _err "get zone failed"
   return 1
 }
 
 _cf_rest() {
-  m=$1
-  ep="$2"
+  method="$1"
+  request="$2"
   data="$3"
-  _debug "$ep"
 
   export _H1="X-Auth-Email: $CF_Email"
   export _H2="X-Auth-Key: $CF_Key"
   export _H3="Content-Type: application/json"
 
-  if [ "$m" != "GET" ]; then
-    _debug data "$data"
-    response="$(_post "$data" "$CF_Api/$ep" "" "$m")"
+  if [ "$method" = "GET" ]; then
+    _debug request "$request"
+    response="$(_get "$CF_API/$request" "" "")"
   else
-    response="$(_get "$CF_Api/$ep")"
+    _debug data "$data"
+    _debug request "$request"
+    response="$(_post "$data" "$CF_API/$request" "" "$method")"
   fi
 
   if [ "$?" != "0" ]; then
-    _err "error $ep"
+    _err "error for request: $request"
     return 1
   fi
+
   _debug2 response "$response"
   return 0
 }


### PR DESCRIPTION
- Cleanup for general consistency, keeping changes to a minimum.
- Consistently use `_egrep_o` ... `_head_n` ... `sed` to extract JSON values
- Use `_contains` instead of `grep`
- Rename key private variables to begin with `_cf_`
- Rename `_get_root` to `_cf_get_zone`, remove unused `_sub_domain` variable
- In `_cf_rest` rename arg variables to be more descriptive, 

Note: The API response `"success":true` seems to occur more often then you would think it should.

Note: To be more robust
```
_contains "$response" '"success":true'
```
could be written as
```
_contains "$response" '"success" *: *true'
```
but I was not sure if you wanted `_contains` to use regex's as a practice.  It currently works fine as is.

I have tested it, issued a couple certificates, monitored the debug output, and it looks good to my eye.
