### PR TITLE
Update DuckDNS support, fix failure on first call, no longer save the…

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -512,13 +512,10 @@ export DuckDNS_Token="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 ```
 
 Please note that since DuckDNS uses StartSSL as their cert provider, thus 
---insecure must be used when issuing certs:
+--insecure may need to be used when issuing certs:
 ```
 acme.sh --insecure --issue --dns dns_duckdns -d mydomain.duckdns.org
 ```
-
-Also, DuckDNS uses the domain name as username for recording changing, so the
-account file will always store the lastly used domain name.
 
 For issues, please report to https://github.com/raidenii/acme.sh/issues.
 


### PR DESCRIPTION
… domain/username as a global, and other tweaks

Remove `API_Params` since on first call `DuckDNS_Domain` was not initialized and it failed.

No longer save `DuckDNS_Domain` but rather calculate it (now `_duckdns_domain`) from `fulldomain` every time.  Multiple domains within the same account should now work.

Fix _egrep_o regex to match a dot, not any character

Tweak comments to not imply ``--insecure`` is always needed, works for me with `curl` and the latest Mozilla ca-bundle.crt.