### PR TITLE
Support for busybox in time2str()

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1367,6 +1367,10 @@ _time2str() {
     echo "$_t_s_a"
   fi
 
+  #Busybox
+  if echo "$1" | awk '{ print strftime("%c", $0); }' 2>/dev/null; then
+    return
+  fi
 }
 
 _normalizeJson() {


### PR DESCRIPTION
'cause busybox's date doesn't work as expected, running acme.sh on it will result in missing date string for renewal. Using awk function "strftime" it works.