### PR TITLE
[cloudns] Add support for sub user IDs

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -409,10 +409,13 @@ acme.sh --issue --dns dns_dgon -d example.com -d www.example.com
 
 ## 21. Use ClouDNS.net API
 
-You need to set the HTTP API user ID and password credentials. See: https://www.cloudns.net/wiki/article/42/
+You need to set the HTTP API user ID and password credentials. See: https://www.cloudns.net/wiki/article/42/. For security reasons, it's recommended to use a sub user ID that only has access to the necessary zones, as a regular API user has access to your entire account.
 
 ```
-export CLOUDNS_AUTH_ID=XXXXX
+# Use this for a sub auth ID
+export CLOUDNS_SUB_AUTH_ID=XXXXX
+# Use this for a regular auth ID
+#export CLOUDNS_AUTH_ID=XXXXX
 export CLOUDNS_AUTH_PASSWORD="YYYYYYYYY"
 ```
 

--- a/dnsapi/dns_cloudns.sh
+++ b/dnsapi/dns_cloudns.sh
@@ -97,17 +97,19 @@ _dns_cloudns_init_check() {
   fi
 
   CLOUDNS_AUTH_ID="${CLOUDNS_AUTH_ID:-$(_readaccountconf_mutable CLOUDNS_AUTH_ID)}"
+  CLOUDNS_SUB_AUTH_ID="${CLOUDNS_SUB_AUTH_ID:-$(_readaccountconf_mutable CLOUDNS_SUB_AUTH_ID)}"
   CLOUDNS_AUTH_PASSWORD="${CLOUDNS_AUTH_PASSWORD:-$(_readaccountconf_mutable CLOUDNS_AUTH_PASSWORD)}"
-  if [ -z "$CLOUDNS_AUTH_ID" ] || [ -z "$CLOUDNS_AUTH_PASSWORD" ]; then
+  if [ -z "$CLOUDNS_AUTH_ID$CLOUDNS_SUB_AUTH_ID" ] || [ -z "$CLOUDNS_AUTH_PASSWORD" ]; then
     CLOUDNS_AUTH_ID=""
+    CLOUDNS_SUB_AUTH_ID=""
     CLOUDNS_AUTH_PASSWORD=""
     _err "You don't specify cloudns api id and password yet."
     _err "Please create you id and password and try again."
     return 1
   fi
 
-  if [ -z "$CLOUDNS_AUTH_ID" ]; then
-    _err "CLOUDNS_AUTH_ID is not configured"
+  if [ -z "$CLOUDNS_AUTH_ID" ] && [ -z "$CLOUDNS_SUB_AUTH_ID" ]; then
+    _err "CLOUDNS_AUTH_ID or CLOUDNS_SUB_AUTH_ID is not configured"
     return 1
   fi
 
@@ -125,6 +127,7 @@ _dns_cloudns_init_check() {
 
   #save the api id and password to the account conf file.
   _saveaccountconf_mutable CLOUDNS_AUTH_ID "$CLOUDNS_AUTH_ID"
+  _saveaccountconf_mutable CLOUDNS_SUB_AUTH_ID "$CLOUDNS_SUB_AUTH_ID"
   _saveaccountconf_mutable CLOUDNS_AUTH_PASSWORD "$CLOUDNS_AUTH_PASSWORD"
 
   CLOUDNS_INIT_CHECK_COMPLETED=1
@@ -168,12 +171,19 @@ _dns_cloudns_http_api_call() {
   method=$1
 
   _debug CLOUDNS_AUTH_ID "$CLOUDNS_AUTH_ID"
+  _debug CLOUDNS_SUB_AUTH_ID "$CLOUDNS_SUB_AUTH_ID"
   _debug CLOUDNS_AUTH_PASSWORD "$CLOUDNS_AUTH_PASSWORD"
 
-  if [ -z "$2" ]; then
-    data="auth-id=$CLOUDNS_AUTH_ID&auth-password=$CLOUDNS_AUTH_PASSWORD"
+  if [ ! -z "$CLOUDNS_SUB_AUTH_ID" ]; then
+    auth_user="sub-auth-id=$CLOUDNS_SUB_AUTH_ID"
   else
-    data="auth-id=$CLOUDNS_AUTH_ID&auth-password=$CLOUDNS_AUTH_PASSWORD&$2"
+    auth_user="auth-id=$CLOUDNS_AUTH_ID"
+  fi;
+
+  if [ -z "$2" ]; then
+    data="$auth_user&auth-password=$CLOUDNS_AUTH_PASSWORD"
+  else
+    data="$auth_user&auth-password=$CLOUDNS_AUTH_PASSWORD&$2"
   fi
 
   response="$(_get "$CLOUDNS_API/$method?$data")"

--- a/dnsapi/dns_cloudns.sh
+++ b/dnsapi/dns_cloudns.sh
@@ -4,6 +4,7 @@
 # Repository: https://github.com/ClouDNS/acme.sh/
 
 #CLOUDNS_AUTH_ID=XXXXX
+#CLOUDNS_SUB_AUTH_ID=XXXXX
 #CLOUDNS_AUTH_PASSWORD="YYYYYYYYY"
 CLOUDNS_API="https://api.cloudns.net"
 
@@ -178,7 +179,7 @@ _dns_cloudns_http_api_call() {
     auth_user="sub-auth-id=$CLOUDNS_SUB_AUTH_ID"
   else
     auth_user="auth-id=$CLOUDNS_AUTH_ID"
-  fi;
+  fi
 
   if [ -z "$2" ]; then
     data="$auth_user&auth-password=$CLOUDNS_AUTH_PASSWORD"


### PR DESCRIPTION
Adds support for CloudNS sub user IDs. Sub user IDs can be restricted to only have access to particular DNS zones, so it's more secure than using a regular user ID (which has access to the entire account).

Example run:
```
daniel@Daniel-PC:/mnt/c/src/acme.sh$ export CLOUDNS_SUB_AUTH_ID=178
daniel@Daniel-PC:/mnt/c/src/acme.sh$ export CLOUDNS_AUTH_PASSWORD="xxxxxxxxx"
daniel@Daniel-PC:/mnt/c/src/acme.sh$ ./acme.sh --test --issue --dns dns_cloudns -d test.internal.d.sb
[Tue Oct 31 22:30:14 DST 2017] Using stage ACME_DIRECTORY: https://acme-staging.api.letsencrypt.org/directory
[Tue Oct 31 22:30:15 DST 2017] Single domain='test.internal.d.sb'
[Tue Oct 31 22:30:16 DST 2017] Getting domain auth token for each domain
[Tue Oct 31 22:30:16 DST 2017] Getting webroot for domain='test.internal.d.sb'
[Tue Oct 31 22:30:16 DST 2017] Getting new-authz for domain='test.internal.d.sb'
[Tue Oct 31 22:30:18 DST 2017] The new-authz request is ok.
[Tue Oct 31 22:30:18 DST 2017] Found domain api file: /mnt/c/src/acme.sh/dnsapi/dns_cloudns.sh
[Tue Oct 31 22:30:18 DST 2017] Using cloudns
[Tue Oct 31 22:30:25 DST 2017] Adding the TXT record for _acme-challenge.test.internal.d.sb
[Tue Oct 31 22:30:27 DST 2017] Added.
[Tue Oct 31 22:30:27 DST 2017] Sleep 120 seconds for the txt records to take effect
[Tue Oct 31 22:32:33 DST 2017] Verifying:test.internal.d.sb
[Tue Oct 31 22:32:37 DST 2017] Success
[Tue Oct 31 22:32:37 DST 2017] Using cloudns
[Tue Oct 31 22:32:44 DST 2017] Deleting the TXT record for _acme-challenge.test.internal.d.sb
[Tue Oct 31 22:32:46 DST 2017] Deleted.
[Tue Oct 31 22:32:46 DST 2017] Verify finished, start to sign.
[Tue Oct 31 22:32:47 DST 2017] Cert success.
-----BEGIN CERTIFICATE-----
... snipped ...
-----END CERTIFICATE-----
[Tue Oct 31 22:32:47 DST 2017] Your cert is in  /home/daniel/.acme.sh/test.internal.d.sb/test.internal.d.sb.cer
[Tue Oct 31 22:32:47 DST 2017] Your cert key is in  /home/daniel/.acme.sh/test.internal.d.sb/test.internal.d.sb.key
[Tue Oct 31 22:32:47 DST 2017] The intermediate CA cert is in  /home/daniel/.acme.sh/test.internal.d.sb/ca.cer
[Tue Oct 31 22:32:47 DST 2017] And the full chain certs is there:  /home/daniel/.acme.sh/test.internal.d.sb/fullchain.cer
```

cc @boyanpeychev