### PR TITLE
fix bug in the --ca-bundle param of passing -f to _readlink

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5510,7 +5510,7 @@ _process() {
         HTTPS_INSECURE="1"
         ;;
       --ca-bundle)
-        _ca_bundle="$(_readlink -f "$2")"
+        _ca_bundle="$(_readlink "$2")"
         CA_BUNDLE="$_ca_bundle"
         shift
         ;;


### PR DESCRIPTION
When _readlink is called the -f param must not be passed. _readlink (with
leading underscore) is a wrapper around readlink (without leading
underscore). _readlink already passes -f to readlink, that's why it must
not be passed to _readlink.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->