### PR TITLE
Consider a 200 final response code as an account that already exists. Fixes #1242

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3170,7 +3170,7 @@ _regAccount() {
   if [ "$code" = "" ] || [ "$code" = '201' ]; then
     echo "$response" >"$ACCOUNT_JSON_PATH"
     _info "Registered"
-  elif [ "$code" = '409' ]; then
+  elif [ "$code" = '409' ] || [ "$code" = '200' ]; then
     _info "Already registered"
   else
     _err "Register account Error: $response"


### PR DESCRIPTION
When registering against a v2 API server, an account that already exists returns a 200 code, unlike v1. Take that into account when processing the response. See #1242 for more info.