### PR TITLE
Test ACME v2 before copying certificate to fullchain (again)

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4078,7 +4078,9 @@ $_authorizations_map"
       _info "Your cert key is in $(__green " $CERT_KEY_PATH ")"
     fi
 
-    cp "$CERT_PATH" "$CERT_FULLCHAIN_PATH"
+    if [ "$ACME_VERSION" != "2" ]; then
+      cp "$CERT_PATH" "$CERT_FULLCHAIN_PATH"
+    fi
 
     if [ ! "$USER_PATH" ] || [ ! "$IN_CRON" ]; then
       USER_PATH="$PATH"


### PR DESCRIPTION
Without this, the work done a few lines above is clobbered, leaving the fullchain.cer containing only the certificate, not the CA and certificate chain.

See #1330