### PR TITLE
cache content of stdin for reuse in `_egrep_o()`, this should fix #1364

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -793,8 +793,9 @@ _sed_i() {
 }
 
 _egrep_o() {
-  if ! egrep -o "$1" 2>/dev/null; then
-    sed -n 's/.*\('"$1"'\).*/\1/p'
+  stdin=$(cat)
+  if ! echo "$stdin" | egrep -o "$1" 2>/dev/null; then
+    echo "$stdin" | sed -n 's/.*\('"$1"'\).*/\1/p'
   fi
 }
 


### PR DESCRIPTION
In the original implementation,

```
_egrep_o() {
  if ! egrep -o "$1" 2>/dev/null; then
    sed -n 's/.*\('"$1"'\).*/\1/p'
  fi
}
```

If `egrep` fails, it has already consumed stdin, and `sed` will get nothing input.

We cache stdin content to local variable, so it can be reused. 