### PR TITLE
DNS-Manual: better documentation in script

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3819,7 +3819,7 @@ $_authorizations_map"
     if [ "$dnsadded" = '0' ]; then
       _savedomainconf "Le_Vlist" "$vlist"
       _debug "Dns record not added yet, so, save to $DOMAIN_CONF and exit."
-      _err "Please add the TXT records to the domains, and retry again."
+      _err "Please add the TXT records to the domains, and re-run with --renew."
       _clearup
       _on_issue_err "$_post_hook"
       return 1


### PR DESCRIPTION
Change the hint that tells you how to use DNS manual (second run needs to be --renew)
