### PR TITLE
Added additional information for do.de users

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -325,6 +325,8 @@ The `CY_Username`, `CY_Password` and `CY_OTP_Secret` will be saved in `~/.acme.s
 
 ## 17. Use Domain-Offensive/Resellerinterface/Domainrobot API
 
+ATTENTION: You need to be a registered Reseller to be able to use the ResellerInterface. As a normal user you can not use this method.
+
 You will need your login credentials (Partner ID+Password) to the Resellerinterface, and export them before you run `acme.sh`:
 ```
 export DO_PID="KD-1234567"


### PR DESCRIPTION
I tried to obtain a wildcard cert with a domain hosted at domain-offensive. For a normal user like me it is not possible to use the provided dns module as the reseller interface is only accessible for registered do.de reseller.
So i have added a comment to the README to inform users, who are trying to do the same like me.