### PR TITLE
Disable line wrapping on base64 conversion to prevent auth failure

### DIFF
--- a/dnsapi/dns_namecom.sh
+++ b/dnsapi/dns_namecom.sh
@@ -123,7 +123,7 @@ _namecom_login() {
   # Auth string
   # Name.com API v4 uses http basic auth to authenticate
   # need to convert the token for http auth
-  _namecom_auth=$(printf "%s:%s" "$Namecom_Username" "$Namecom_Token" | base64)
+  _namecom_auth=$(printf "%s:%s" "$Namecom_Username" "$Namecom_Token" | _base64)
 
   if _namecom_rest GET "hello"; then
     retcode=$(printf "%s\n" "$response" | _egrep_o "\"username\"\:\"$Namecom_Username\"")


### PR DESCRIPTION
Base64 by default wraps lines at 76 chars, the line break was resolving as the incorrect auth string.
~See http://man7.org/linux/man-pages/man1/base64.1.html for details on cmd flag~

Edit:  Amended commit to reflect pr feedback.
