### PR TITLE
Fixed Dreamhost ENV var name in dnsapi/README.md

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -750,7 +750,7 @@ DNS API keys may be created at https://panel.dreamhost.com/?tree=home.api.
 Ensure the created key has add and remove privelages.
 
 ```
-export DH_API_Key="<api key>"
+export DH_API_KEY="<api key>"
 acme.sh --issue --dns dns_dreamhost -d example.com -d www.example.com
 ```
 


### PR DESCRIPTION
Fixed the Dreamhost variable name in the dnsapi/README.md 