### PR TITLE
dns_he - proposed fix for #1438

### DIFF
--- a/dnsapi/dns_he.sh
+++ b/dnsapi/dns_he.sh
@@ -143,7 +143,7 @@ _find_zone() {
 
     _debug "Looking for zone \"${_attempted_zone}\""
 
-    line_num="$(echo "$_zone_names" | grep -n "$_attempted_zone" | cut -d : -f 1)"
+    line_num="$(echo "$_zone_names" | grep -n "^$_attempted_zone" | cut -d : -f 1)"
 
     if [ "$line_num" ]; then
       _zone_id=$(echo "$_zone_ids" | sed -n "${line_num}p")


### PR DESCRIPTION
proposed fix for #1438
if you have more than one zone of  for domain (e.g.  example.com and subdomain.example.com) _find_zone fails because it matches 2 lines (example.com and subdomain.example.com) 
This fix removes partials matches and matches only example.com if you issue the cert for example.com


<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->