### PR TITLE
Update to use openssl base64 vs native base64

### DIFF
--- a/dnsapi/dns_namecom.sh
+++ b/dnsapi/dns_namecom.sh
@@ -123,7 +123,7 @@ _namecom_login() {
   # Auth string
   # Name.com API v4 uses http basic auth to authenticate
   # need to convert the token for http auth
-  _namecom_auth=$(printf "%s:%s" "$Namecom_Username" "$Namecom_Token" | base64)
+  _namecom_auth=$(printf "%s:%s" "$Namecom_Username" "$Namecom_Token" | /usr/bin/openssl base64 -e)
 
   if _namecom_rest GET "hello"; then
     retcode=$(printf "%s\n" "$response" | _egrep_o "\"username\"\:\"$Namecom_Username\"")


### PR DESCRIPTION
Not all systems use base64 (read pfSense)

Instead of using `base64`, they should use `/usr/bin/openssl base64 -e`
Ref: https://www.reddit.com/r/PFSENSE/comments/87477p/trying_to_issue_acme_cert_base64_not_found/

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->