### PR TITLE
freedns: fix domain splitting for multi-part domains

### DIFF
--- a/dnsapi/dns_freedns.sh
+++ b/dnsapi/dns_freedns.sh
@@ -47,11 +47,10 @@ dns_freedns_add() {
   _saveaccountconf FREEDNS_COOKIE "$FREEDNS_COOKIE"
 
   # split our full domain name into two parts...
-  i="$(echo "$fulldomain" | tr '.' ' ' | wc -w)"
-  i="$(_math "$i" - 1)"
-  top_domain="$(echo "$fulldomain" | cut -d. -f "$i"-100)"
-  i="$(_math "$i" - 1)"
-  sub_domain="$(echo "$fulldomain" | cut -d. -f -"$i")"
+  # top_domain is everything after the first dot
+  # sub_domain is the element before the first dot
+  top_domain="$(echo "$fulldomain" | cut -d. -f 2-)"
+  sub_domain="$(echo "$fulldomain" | cut -d. -f 1)"
 
   _debug "top_domain: $top_domain"
   _debug "sub_domain: $sub_domain"


### PR DESCRIPTION
It seems that the way domains were split before was using some unnecessarily complex maths which was broken for domains >3 parts (e.g `_acme-challenge.test.domain.com`)

I assume what the correct behaviour should be is the following:
```
sub_domain='_acme-challenge'
top_domain='everything.after.the.first.dot.com'
```

This PR fixes for domains >3 parts and still works for simple `sub.domain.com` domains