### PR TITLE
Fix dns_selectel work with unicode domains

### DIFF
--- a/dnsapi/dns_selectel.sh
+++ b/dnsapi/dns_selectel.sh
@@ -104,7 +104,7 @@ dns_selectel_rm() {
 # _domain=domain.com
 # _domain_id=sdjkglgdfewsdfg
 _get_root() {
-  domain=$1
+  domain="$(echo "$1" | idn -u)"
 
   if ! _sl_rest GET "/"; then
     return 1
@@ -124,7 +124,7 @@ _get_root() {
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
       _domain=$h
       _debug "Getting domain id for $h"
-      if ! _sl_rest GET "/$h"; then
+      if ! _sl_rest GET "/$(_idn "$h")"; then
         return 1
       fi
       _domain_id="$(echo "$response" | tr "," "\n" | tr "}" "\n" | tr -d " " | grep "\"id\":" | cut -d : -f 2)"
@@ -147,9 +147,9 @@ _sl_rest() {
 
   if [ "$m" != "GET" ]; then
     _debug data "$data"
-    response="$(_post "$data" "$SL_Api/$ep" "" "$m")"
+    response="$(printf '%b' "$(_post "$data" "$SL_Api/$ep" "" "$m")")"
   else
-    response="$(_get "$SL_Api/$ep")"
+    response="$(printf '%b' "$(_get "$SL_Api/$ep")")"
   fi
 
   if [ "$?" != "0" ]; then


### PR DESCRIPTION
For example, I want to issue certificate for domain `тест.рф` (punycode `xn--e1aybc.xn--p1ai`)
Domain not contains in response from selectel because it escaped in response: `\u0442\u0435\u0441\u0442.\u0440\u0444` and `_contains` function cannot found it.

This PR does:

- replace domain to utf before `_get_root` with `idn -u` for `_contains` works
- unescape response with `echo -e` for `_contains` works
- convert domain to punycode before selectel api request with `idn` for api works

I think that would be better to escape domain instead of unescape response, but I don't know how to convert `тест.рф` to `\u0442\u0435\u0441\u0442.\u0440\u0444`.

Tested with all of: `тест.рф`, `xn--e1aybc.xn--p1ai`, `example.com`