### PR TITLE
Fix DNSimple when zone has > 100 records

### DIFF
--- a/dnsapi/dns_dnsimple.sh
+++ b/dnsapi/dns_dnsimple.sh
@@ -152,7 +152,7 @@ _get_records() {
   sub_domain=$3
 
   _debug "fetching txt records"
-  _dnsimple_rest GET "$account_id/zones/$domain/records?per_page=100"
+  _dnsimple_rest GET "$account_id/zones/$domain/records?per_page=100&sort=id:desc"
 
   if ! _contains "$response" "\"id\":"; then
     _err "failed to retrieve records"


### PR DESCRIPTION
The _get_records function currently returns the first 100 records. As our TXT is added most recently, if you have > 100 records it will not be returned.

I've changed the function to sort by ID DESC, so it will always return the latest 100 records.