### PR TITLE
Increase serial when adding txt records

### DIFF
--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -128,7 +128,7 @@ _ISPC_addTxt() {
   curSerial="$(date +%s)"
   curStamp="$(date +'%F %T')"
   params="\"server_id\":\"${server_id}\",\"zone\":\"${zone}\",\"name\":\"${fulldomain}.\",\"type\":\"txt\",\"data\":\"${txtvalue}\",\"aux\":\"0\",\"ttl\":\"3600\",\"active\":\"y\",\"stamp\":\"${curStamp}\",\"serial\":\"${curSerial}\""
-  curData="{\"session_id\":\"${sessionID}\",\"client_id\":\"${client_id}\",\"params\":{${params}}}"
+  curData="{\"session_id\":\"${sessionID}\",\"client_id\":\"${client_id}\",\"params\":{${params}},\"update_serial\":true}}"
   curResult="$(_post "${curData}" "${ISPC_Api}?dns_txt_add")"
   _debug "Calling _ISPC_addTxt: '${curData}' '${ISPC_Api}?dns_txt_add'"
   _debug "Result of _ISPC_addTxt: '$curResult'"

--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -128,7 +128,7 @@ _ISPC_addTxt() {
   curSerial="$(date +%s)"
   curStamp="$(date +'%F %T')"
   params="\"server_id\":\"${server_id}\",\"zone\":\"${zone}\",\"name\":\"${fulldomain}.\",\"type\":\"txt\",\"data\":\"${txtvalue}\",\"aux\":\"0\",\"ttl\":\"3600\",\"active\":\"y\",\"stamp\":\"${curStamp}\",\"serial\":\"${curSerial}\""
-  curData="{\"session_id\":\"${sessionID}\",\"client_id\":\"${client_id}\",\"params\":{${params}},\"update_serial\":true}}"
+  curData="{\"session_id\":\"${sessionID}\",\"client_id\":\"${client_id}\",\"params\":{${params}},\"update_serial\":true}"
   curResult="$(_post "${curData}" "${ISPC_Api}?dns_txt_add")"
   _debug "Calling _ISPC_addTxt: '${curData}' '${ISPC_Api}?dns_txt_add'"
   _debug "Result of _ISPC_addTxt: '$curResult'"
@@ -160,7 +160,7 @@ _ISPC_rmTxt() {
       *)
         unset IFS
         _info "Retrieved Record ID."
-        curData="{\"session_id\":\"${sessionID}\",\"primary_id\":\"${record_id}\"}"
+        curData="{\"session_id\":\"${sessionID}\",\"primary_id\":\"${record_id}\",\"update_serial\":true}"
         curResult="$(_post "${curData}" "${ISPC_Api}?dns_txt_delete")"
         _debug "Calling _ISPC_rmTxt: '${curData}' '${ISPC_Api}?dns_txt_delete'"
         _debug "Result of _ISPC_rmTxt: '$curResult'"


### PR DESCRIPTION
This should fix #1198 for people running Ispconfig `3.1.12`

Still waiting on an answer from the ISPC maintainer, if we need to increase serial on the remove action as well in order to avoid zone transfer failures at that point.

Checkout the conversation on their issue tracker: https://git.ispconfig.org/ispconfig/ispconfig3/issues/4806

**Update:** there is a fix in progress on their end, to also update the serial, when deleting. Will update the PR at that point.