### PR TITLE
BSD fix _time2str()

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1374,17 +1374,17 @@ _url_replace() {
 }
 
 _time2str() {
-  #Linux
-  if date -u -d@"$1" 2>/dev/null; then
-    return
-  fi
-
   #BSD
   if date -u -r "$1" 2>/dev/null; then
     return
   fi
 
-  #Soaris
+  #Linux
+  if date -u -d@"$1" 2>/dev/null; then
+    return
+  fi
+
+  #Solaris
   if _exists adb; then
     _t_s_a=$(echo "0t${1}=Y" | adb)
     echo "$_t_s_a"


### PR DESCRIPTION
date -u -d@"12345" does not produce an error on *BSD and outputs the
current date in UTC, which is not the expected output from _time2str()

Fix, reorder _time2str() to attempt BSD style date first, which
errors on Linux, so cascade style OS detection works correctly.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->