### PR TITLE
Create a draft version of pleskxml API for DNS01

### DIFF
--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -72,27 +72,25 @@ _DBG_EARLY_CHECK_MODE() {
   fi
 }
 
-# arg1 = LINENO
-# arg2 = severity level (1=least serious, 3=most serious)
+# arg1 = severity level (1=least serious, 3=most serious)
 #   By design if DBG level is 9 for a MESSAGE, the message is ALWAYS shown, this is used for _info and _err
-# arg3 = message
+# arg2 = message
 _DBG() {
-  if [ "$2" -eq 9 ] || ([ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$2" -ge "$_pleskxml_DBG_LEVEL" ]); then
-    case $2 in
+  if [ "$1" -eq 9 ] || ([ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_DBG_LEVEL" ]); then
+    case $1 in
       1) _pleskxml_severity='MAX_DETAIL' ;;
       2) _pleskxml_severity='DETAIL' ;;
       3) _pleskxml_severity='INFO' ;;
       9) _pleskxml_severity='ACME.SH' ;;
     esac
     _pleskxml_DBG_COUNT=$((_pleskxml_DBG_COUNT + 1))
-    printf '%04d DEBUG [%s/%d, line %s]:\n%s\n\n' "$_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$2" "$1" "$3"
+    printf '%04d DEBUG [%s/%d]:\n%s\n\n' "$_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$1" "$2"
   fi
 }
 
-# arg1 = LINENO
-# arg2 = severity level (1=least serious, 3=most serious)
+# arg1 = severity level (1=least serious, 3=most serious)
 _DBG_VARDUMP() {
-  _DBG "$1" "$2" "$(printf '1st lines of current defined variables are now:\n%s\n\n' "$(set | grep '_pleskxml' | sort)")"
+  _DBG "$1" "$(printf '1st lines of current defined variables are now:\n%s\n\n' "$(set | grep '_pleskxml' | sort)")"
 }
 
 _DBG_ERR_TRAP() {
@@ -148,7 +146,7 @@ _pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-
 
 dns_pleskxml_add() {
 
-  _DBG "$LINENO" 3 "Entered dns_pleskxml_add($*)..."
+  _DBG 3 "Entered dns_pleskxml_add($*)..."
 
   _pleskxml_FQDN="$1"
   _pleskxml_TXT_string="$2"
@@ -163,9 +161,9 @@ dns_pleskxml_add() {
   _pleskxml_get_variables
   _pleskxml_retcode=$?
 
-  _DBG "$LINENO" 3 'Returned from _pleskxml_get_variables(). Back in dns_pleskxml_add().'
-  _DBG_VARDUMP "$LINENO" 2
-  
+  _DBG 3 'Returned from _pleskxml_get_variables(). Back in dns_pleskxml_add().'
+  _DBG_VARDUMP 2
+
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
     _err "$_pleskxml_errors"
     return 1
@@ -180,14 +178,14 @@ dns_pleskxml_add() {
   _info "Plesk XML: Variables are valid and loaded."
   _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-  _DBG "$LINENO" 3 "Calling API to get domain ID for $_pleskxml_domain"
+  _DBG 3 "Calling API to get domain ID for $_pleskxml_domain"
 
   _pleskxml_get_domain_ID "$_pleskxml_domain"
   _pleskxml_retcode=$?
 
-  _DBG "$LINENO" 3 'Returned from API call. Back in dns_pleskxml_add().'
-  _DBG_VARDUMP "$LINENO" 2
-  
+  _DBG 3 'Returned from API call. Back in dns_pleskxml_add().'
+  _DBG_VARDUMP 2
+
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
     _err "$_pleskxml_errors"
@@ -199,15 +197,15 @@ dns_pleskxml_add() {
 
   # Try to add the TXT record
 
-  _DBG "$LINENO" 3 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+  _DBG 3 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
   _info "Plesk XML: Got ID for domain. Trying to add TXT record to domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'. The TXT string is: '$_pleskxml_TXT_string'."
 
   _pleskxml_add_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
   _pleskxml_retcode=$?
 
-  _DBG "$LINENO" 3 'Call has returned. dns_pleskxml_add().'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 3 'Call has returned. dns_pleskxml_add().'
+  _DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -217,7 +215,7 @@ dns_pleskxml_add() {
 
   _info 'An ACME Challenge TXT record for '"$_pleskxml_domain"' was added to Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
 
-  _DBG "$LINENO" 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
+  _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
 
   return 0
 }
@@ -227,7 +225,7 @@ dns_pleskxml_add() {
 
 dns_pleskxml_rm() {
 
-  _DBG "$LINENO" 2 "Entered dns_pleskxml_rm($*)..."
+  _DBG 2 "Entered dns_pleskxml_rm($*)..."
 
   _pleskxml_FQDN="$1"
   _pleskxml_TXT_string="$2"
@@ -242,8 +240,8 @@ dns_pleskxml_rm() {
   _pleskxml_get_variables
   _pleskxml_retcode=$?
 
-  _DBG "$LINENO" 2 'Called _pleskxml_get_variables()'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'Called _pleskxml_get_variables()'
+  _DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
     _err "$_pleskxml_errors"
@@ -259,13 +257,13 @@ dns_pleskxml_rm() {
   _info "Plesk XML: Variables are valid and loaded."
   _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-  _DBG "$LINENO" 2 "Calling API to get domain ID for $_pleskxml_domain"
+  _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
   _pleskxml_get_domain_ID "$_pleskxml_domain"
   _pleskxml_retcode=$?
 
-  _DBG "$LINENO" 2 'Call has returned'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'Call has returned'
+  _DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -280,13 +278,13 @@ dns_pleskxml_rm() {
 
   _info "Plesk XML: Got ID for domain. Trying to remove TXT record from domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'."
 
-  _DBG "$LINENO" 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+  _DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
   _pleskxml_rmv_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
   _pleskxml_retcode=$?
 
-  _DBG "$LINENO" 2 'Call has returned'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'Call has returned'
+  _DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -296,7 +294,7 @@ dns_pleskxml_rm() {
 
   _info 'A TXT record for '"$_pleskxml_domain"' was removed from Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
 
-  _DBG "$LINENO" 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
+  _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
 
   return 0
 }
@@ -307,8 +305,8 @@ dns_pleskxml_rm() {
 
 _pleskxml_get_variables() {
 
-  _DBG "$LINENO" 2 'Entered _pleskxml_get_variables()'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'Entered _pleskxml_get_variables()'
+  _DBG_VARDUMP 2
 
   _pleskxml_errors=''
 
@@ -366,13 +364,13 @@ _pleskxml_get_variables() {
   _pleskxml_optional_curl_args="${pleskxml_optional_curl_args:-}"
 
   if [ "$_pleskxml_errors" != '' ]; then
-    _DBG "$LINENO" 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
-    _DBG_VARDUMP "$LINENO" 2
+    _DBG 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
+    _DBG_VARDUMP 2
     _err 'Can'\''t parse user-defined variables. Exiting.'
     return 1
   else
-    _DBG "$LINENO" 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
-    _DBG_VARDUMP "$LINENO" 2
+    _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
+    _DBG_VARDUMP 2
     return 0
   fi
 }
@@ -383,7 +381,7 @@ _pleskxml_get_variables() {
 
 _pleskxml_api_request() {
 
-  _DBG "$LINENO" 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
+  _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
 
   _pleskxml_errors=''
   _pleskxml_result=''
@@ -417,14 +415,14 @@ _pleskxml_api_request() {
          -d '${_pleskxml_APICMD}' \
          ${_pleskxml_optional_curl_args}"
 
-  _DBG "$LINENO" 2 'About to call Plesk via cURL'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'About to call Plesk via cURL'
+  _DBG_VARDUMP 2
 
-  _DBG "$LINENO" 2 "$(printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri")"
+  _DBG 2 "$(printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri")"
   _pleskxml_prettyprint_result="$(eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null)"
   _pleskxml_retcode="$?"
-  _DBG "$LINENO" 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
-  _DBG "$LINENO" 2 "retcode = $_pleskxml_retcode"
+  _DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
+  _DBG 2 "retcode = $_pleskxml_retcode"
 
   # BUGFIX TO CHECK - WILL RETCODE FROM cURL BE AVAILABLE HERE?
 
@@ -448,15 +446,15 @@ _pleskxml_api_request() {
     | tr -d '\n'
   )"
 
-  _DBG "$LINENO" 2 'cURL succeeded, valid cURL response obtained'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'cURL succeeded, valid cURL response obtained'
+  _DBG_VARDUMP 2
 
   # Now we need to check item by item if it's OK.
   # As we go, we will strip out "known OK" stuff to leave the core reply.
 
   # XML header and packet version?
 
-  _DBG "$LINENO" 2 'Checking <?xml> and <packet> tags exist...'
+  _DBG 2 'Checking <?xml> and <packet> tags exist...'
 
   if printf '%s' "$_pleskxml_result" | grep -qiEv '^<\?xml version=[^>]+><packet version=[^>]+>.*</packet>$'; then
     # Error - should have <?xml><packet>...</packet>. Abort
@@ -470,7 +468,7 @@ _pleskxml_api_request() {
     )"
   fi
 
-  _DBG "$LINENO" 2 "Checking <system> tags don't exist..."
+  _DBG 2 "Checking <system> tags don't exist..."
 
   # <system> section found anywhere in response?
   # This usually means some kind of basic API error such as login failure, bad XML request, etc
@@ -482,7 +480,7 @@ _pleskxml_api_request() {
     return 1
   fi
 
-  _DBG "$LINENO" 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
+  _DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
 
   # Check results section. Most commands only have one results section.
   # But some (i.e., get all DNS records for a domain) have many results sections,
@@ -501,7 +499,7 @@ _pleskxml_api_request() {
     return 1
   fi
 
-  _DBG "$LINENO" 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
+  _DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | sed "s/<result>/\\${_pleskxml_newline}<result>/g" \
@@ -513,10 +511,10 @@ _pleskxml_api_request() {
 
   _pleskxml_linecount=$(printf '%s\n' "$_pleskxml_result" | wc -l)
 
-  _DBG "$LINENO" 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
+  _DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
 
-  _DBG "$LINENO" 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
+  _DBG_VARDUMP 2
 
   if [ $_pleskxml_multiple_results_allowed -eq 0 ] && [ "$_pleskxml_linecount" -gt 1 ]; then
     # Error - contains multiple <result> sections. Abort
@@ -525,7 +523,7 @@ _pleskxml_api_request() {
     return 1
   fi
 
-  _DBG "$LINENO" 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
+  _DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
 
   # Loop through each <result> section, checking every line has exactly one result section,
   # containing exactly one status section, which contains <status>ok</status>
@@ -535,7 +533,7 @@ _pleskxml_api_request() {
     # _pleskxml_line *should* contain a single result section.
     # Check this is correct.
 
-    # _DBG "$LINENO" "Checking a <result> section... content is ${_pleskxml_line}"
+    # _DBG "Checking a <result> section... content is ${_pleskxml_line}"
 
     if printf '%s' "$_pleskxml_line" | grep -qiEv '^<result>.*</result>$'; then
       # Error - doesn't contain <result>...</result>. Abort
@@ -551,12 +549,12 @@ _pleskxml_api_request() {
     if printf '%s' "$_pleskxml_line" | grep -qiEv '<status>.*</status>'; then
       # Error - doesn't contain <status>...</status>. Abort
       _pleskxml_errors='Error when querying Plesk XML API. A <result> section did not contain a <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-      _DBG "$LINENO" 2 "$_pleskxml_errors"
+      _DBG 2 "$_pleskxml_errors"
       return 1
     elif printf '%s' "$_pleskxml_line" | grep -qiE '<status>.*</status>.*<status>'; then
       # Error - contains <status>...</status>...<status>. Abort
       _pleskxml_errors='Error when querying Plesk XML API. A <result> section contained more than one <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-      _DBG "$LINENO" 2 "$_pleskxml_errors"
+      _DBG 2 "$_pleskxml_errors"
       return 1
     elif printf '%s' "$_pleskxml_line" | grep -qiEv '<status>ok</status>'; then
       # Error - doesn't contain <status>ok</status>. Abort
@@ -565,7 +563,7 @@ _pleskxml_api_request() {
       return 1
     fi
 
-    # _DBG "$LINENO" "Line is OK. Looping to next line or exiting..."
+    # _DBG "Line is OK. Looping to next line or exiting..."
 
   done <<EOL
 $_pleskxml_result
@@ -573,7 +571,7 @@ EOL
 
   # So far so good. Remove all <status>ok</status> sections as they're checked now.
 
-  _DBG "$LINENO" 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
+  _DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | sed -E 's/<status>ok<\/status>//g'
@@ -581,16 +579,16 @@ EOL
 
   # Result is OK. Remove any redundant self-closing tags, and <data> or </data> tags, and exit
 
-  _DBG "$LINENO" 2 'Now removing any self-closing tags, or <data>...</data> tags'
+  _DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g'
   )"
 
-  _DBG "$LINENO" 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
+  _DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
 
-  _DBG "$LINENO" 2 'Successfully exiting Plesk XML API function'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'Successfully exiting Plesk XML API function'
+  _DBG_VARDUMP 2
 
   return 0
 
@@ -598,17 +596,17 @@ EOL
 
 _pleskxml_get_domain_ID() {
 
-  _DBG "$LINENO" 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
+  _DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
 
   # Call cURL to convert a domain name to a plesk domain ID.
 
-  _DBG "$LINENO" 2 'About to make API request (domain name -> domain ID)'
+  _DBG 2 'About to make API request (domain name -> domain ID)'
 
   _pleskxml_api_request "$_pleskxml_tplt_get_domain_id" "$1"
   _pleskxml_retcode=$?
   # $1 is the domain name we wish to convert to a Plesk domain ID
 
-  _DBG "$LINENO" 2 'Returned from API request, now back in get_domain_ID()'
+  _DBG 2 'Returned from API request, now back in get_domain_ID()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -620,7 +618,7 @@ _pleskxml_get_domain_ID() {
 
   # Result should comprise precisely one <result> section
 
-  _DBG "$LINENO" 2 'Testing API return data for one <result> and removing if so'
+  _DBG 2 'Testing API return data for one <result> and removing if so'
 
   if printf '%s' "$_pleskxml_result" | grep -qiEv '^<result>.*</result>$'; then
     # Error - doesn't comprise <result>DOMAINNAME</result>. Something's wrong. Abort
@@ -641,7 +639,7 @@ _pleskxml_get_domain_ID() {
 
   # Result should contain precisely one <filter-id> section, containing the domain name inquired.
 
-  _DBG "$LINENO" 2 'Testing API return data for one <filter-id> and removing if so'
+  _DBG 2 'Testing API return data for one <filter-id> and removing if so'
 
   if printf '%s' "$_pleskxml_result" | grep -qiv "<filter-id>$1</filter-id>"; then
     # Error - doesn't contain <filter-id>DOMAINNAME</filter-id>. Something's wrong. Abort
@@ -662,7 +660,7 @@ _pleskxml_get_domain_ID() {
 
   # All that should be left is one section, containing <id>DOMAIN_ID</id>
 
-  _DBG "$LINENO" 2 "Remaining part of result is now: '$_pleskxml_result' "
+  _DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
 
   if printf '%s' "$_pleskxml_result" | grep -qiEv '^<id>[0-9]+</id>$'; then
     # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
@@ -679,8 +677,8 @@ _pleskxml_get_domain_ID() {
 
   _pleskxml_domain_id="$_pleskxml_result"
 
-  _DBG "$LINENO" 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
+  _DBG_VARDUMP 2
 
   return 0
 
@@ -692,17 +690,17 @@ _pleskxml_get_domain_ID() {
 
 _pleskxml_get_dns_records() {
 
-  _DBG "$LINENO" 2 "Entered Plesk _pleskxml_get_dns_records($*)"
+  _DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
 
   # First, we need to get all DNS records, and check the list is valid
 
-  _DBG "$LINENO" 2 'About to make API request (get DNS records)'
+  _DBG 2 'About to make API request (get DNS records)'
 
   _pleskxml_api_request "$_pleskxml_tplt_get_dns_records" "$1"
   _pleskxml_retcode=$?
   # $1 is the Plesk internal domain ID for the domain
 
-  _DBG "$LINENO" 2 'Returned from API request, now back in get_txt_records()'
+  _DBG 2 'Returned from API request, now back in get_txt_records()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -713,26 +711,26 @@ _pleskxml_get_dns_records() {
   # OK, we should have a <result> section containing a list of DNS records.
   # Now keep only the TXT records
 
-  _DBG "$LINENO" 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+  _DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
 
   if [ -n "${2:-}" ]; then
     _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
       | grep "<type>$2</type>"
     )"
-    _DBG "$LINENO" 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+    _DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
   else
-    _DBG "$LINENO" 2 'Not filtering DNS records. All records will be returned.'
+    _DBG 2 'Not filtering DNS records. All records will be returned.'
   fi
 
-  _DBG "$LINENO" 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
+  _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
   return 0
 }
 
 _pleskxml_add_txt_record() {
 
-  _DBG "$LINENO" 2 "Entered Plesk _pleskxml_add_txt_record($*)"
+  _DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
 
-  _DBG "$LINENO" 2 'About to make API request (add TXT record)'
+  _DBG 2 'About to make API request (add TXT record)'
 
   _pleskxml_api_request "$_pleskxml_tplt_add_txt_record" "$1" "$2" "$3"
   _pleskxml_retcode=$?
@@ -741,7 +739,7 @@ _pleskxml_add_txt_record() {
   # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
   # $3 is the TXT record value
 
-  _DBG "$LINENO" 2 'Returned from API request, now back in add_txt_record()'
+  _DBG 2 'Returned from API request, now back in add_txt_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -766,24 +764,24 @@ _pleskxml_add_txt_record() {
     | sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/"
   )"
 
-  _DBG "$LINENO" 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
+  _DBG_VARDUMP 2
 
   return 0
 }
 
 _pleskxml_rmv_dns_record() {
 
-  _DBG "$LINENO" 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
+  _DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
 
-  _DBG "$LINENO" 2 'About to make API request (rmv TXT record)'
+  _DBG 2 'About to make API request (rmv TXT record)'
 
   _pleskxml_api_request "$_pleskxml_tplt_rmv_dns_record" "$1"
   _pleskxml_retcode=$?
 
   # $1 is the Plesk internal domain ID for the TXT record
 
-  _DBG "$LINENO" 2 'Returned from API request, now back in rmv_dns_record()'
+  _DBG 2 'Returned from API request, now back in rmv_dns_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -793,8 +791,8 @@ _pleskxml_rmv_dns_record() {
 
   # OK, we should have removed a TXT record. If it failed, there wouldn't have been a "status:ok" above
 
-  _DBG "$LINENO" 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
+  _DBG_VARDUMP 2
 
   return 0
 }
@@ -804,13 +802,13 @@ _pleskxml_rmv_dns_record() {
 # 3rd arg = value of TXT record string to be found and removed
 _pleskxml_rmv_txt_record() {
 
-  _DBG "$LINENO" 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
+  _DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
 
   _pleskxml_get_dns_records "$1" 'TXT'
   _pleskxml_retcode=$?
   # $1 is the Plesk internal domain ID for the domain
 
-  _DBG "$LINENO" 2 'Returned from API request, now back in rmv_txt_record()'
+  _DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -822,7 +820,7 @@ _pleskxml_rmv_txt_record() {
   # Now we need to find our desired record in it (if it exists).
   # and might as well collapse any successful matches to a single line for line-count purposes at the same time
 
-  _DBG "$LINENO" 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
+  _DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." \
@@ -834,7 +832,7 @@ _pleskxml_rmv_txt_record() {
   # ands this avoids regex and escaping which is easier
   # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
 
-  _DBG "$LINENO" 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
+  _DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
 
   if printf '%s' "$_pleskxml_result" | grep -qiE "<result>.*<result>"; then
     # Error - contains <result>...</result>...<result>. Abort
@@ -846,7 +844,7 @@ _pleskxml_rmv_txt_record() {
   if printf '%s\n' "$_pleskxml_result" | grep -qiv "<result>"; then
     # No matching TXT records, so we're done.
     _info "Couldn't find a TXT record matching the requested host/value. Not an error, but a concern..."
-    _DBG "$LINENO" 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
+    _DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
     _pleskxml_result=''
     return 0
   fi
@@ -857,12 +855,12 @@ _pleskxml_rmv_txt_record() {
     | sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/'
   )"
 
-  _DBG "$LINENO" 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
+  _DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
 
   _pleskxml_rmv_dns_record "$_pleskxml_result"
   _pleskxml_retcode=$?
 
-  _DBG "$LINENO" 2 'Returned from API request, now back in rmv_txt_record()'
+  _DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -870,8 +868,8 @@ _pleskxml_rmv_txt_record() {
     return 1
   fi
 
-  _DBG "$LINENO" 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
-  _DBG_VARDUMP "$LINENO" 2
+  _DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
+  _DBG_VARDUMP 2
 
   return 0
 }
@@ -896,70 +894,70 @@ if false; then
 
   _DBG_EARLY_CHECK_MODE
 
-  _DBG "$LINENO" 3 'Debug mode done. Now testing _pleskxml_get_variables()'
+  _DBG 3 'Debug mode done. Now testing _pleskxml_get_variables()'
 
   _pleskxml_get_variables
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '==============================================================='
+  _DBG 3 '==============================================================='
 
-  _DBG "$LINENO" 3 'Testing _pleskxml_get_domain_ID()'
+  _DBG 3 'Testing _pleskxml_get_domain_ID()'
   _pleskxml_get_domain_ID "atticflat.uk"
 
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '==============================================================='
+  _DBG 3 '==============================================================='
 
   test_string="TEST STRING ADDED @ $(date)"
 
-  _DBG "$LINENO" 3 "Testing add a TXT string: '$test_string' "
+  _DBG 3 "Testing add a TXT string: '$test_string' "
   _pleskxml_add_txt_record 874 '_test_subdomain' "$test_string"
 
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '==============================================================='
+  _DBG 3 '==============================================================='
 
-  _DBG "$LINENO" 3 'Testing get DNS records (ALL)'
+  _DBG 3 'Testing get DNS records (ALL)'
   _pleskxml_get_dns_records 874
 
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '==============================================================='
+  _DBG 3 '==============================================================='
 
-  _DBG "$LINENO" 3 'Testing get DNS records (TXT ONLY)'
+  _DBG 3 'Testing get DNS records (TXT ONLY)'
   _pleskxml_get_dns_records 874 TXT
 
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '==============================================================='
+  _DBG 3 '==============================================================='
 
-  _DBG "$LINENO" 3 'Testing rmv a TXT string'
+  _DBG 3 'Testing rmv a TXT string'
   _pleskxml_rmv_txt_record 874 '_test_subdomain' "$test_string"
 
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '==============================================================='
+  _DBG 3 '==============================================================='
 
-  _DBG "$LINENO" 3 'Re-testing get DNS records (TXT ONLY) after TXT string removal'
+  _DBG 3 'Re-testing get DNS records (TXT ONLY) after TXT string removal'
   _pleskxml_get_dns_records 874 TXT
 
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '==============================================================='
+  _DBG 3 '==============================================================='
 
-  _DBG "$LINENO" 3 'Testing rmv a TXT string, with a non-matching string'
+  _DBG 3 'Testing rmv a TXT string, with a non-matching string'
   _pleskxml_rmv_txt_record 874 '_test_subdomain' 'JUNKegqw4bw4bb2'
 
-  _DBG "$LINENO" 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP "$LINENO" 3
+  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _DBG_VARDUMP 3
 
-  _DBG "$LINENO" 3 '=============================================================== END OF RUN'
+  _DBG 3 '=============================================================== END OF RUN'
 
 fi

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -66,7 +66,7 @@ _DBG_EARLY_CHECK_MODE() {
     return 1
   fi
 
-  if [ $_pleskxml_DBG_LEVEL -gt 0 ]; then
+  if [ "$_pleskxml_DBG_LEVEL" -gt 0 ]; then
     _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_DBG_LEVEL}' "
     # This won't display if DBG level was set to zero.
   fi

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -12,11 +12,9 @@
 #   https://docs.plesk.com/en-US/12.5/api-rpc/about-xml-api.28709
 #   and more specifically: https://docs.plesk.com/en-US/12.5/api-rpc/reference.28784
 
-
 # This may be needed if the DNS provider doesn't make the standard Plesk API available to a user.
 # As a result, Plesk can't be configured using usual means or RFC1236. But the XML API is often
 # still left accessible, and is well documented, so it can be used instead, for acme.sh purposes.
-
 
 # API NOTES:
 
@@ -33,7 +31,6 @@
 # 3) The API references domains by a domain ID, when manipulating records. So the code must
 #  initially convert domain names (string) to Plesk domain IDs (numeric).
 
-
 # REQUIRED VARIABLES:
 
 # You need to provide the Plesk URI and login (username and password) as follows:
@@ -42,7 +39,6 @@
 #             (or something similar)
 #   export pleskxml_user="johndoe"
 #   export pleskxml_pass="XXXXX"
-
 
 # OPTIONAL VARIABLES:
 
@@ -58,12 +54,11 @@
 # By design if DBG level is 9 for a message, it is ALWAYS shown, this is used for _info and _err
 #   export pleskxml_debug_min_level=2
 
-
 ############  Before anything else, define dedug functions to be sure they are detected even if while testing #####################
 
 _DBG_EARLY_CHECK_MODE() {
 
-  if printf '%s' "${pleskxml_debug_min_level:-0}" | grep -qE '^[0-3]$' ; then
+  if printf '%s' "${pleskxml_debug_min_level:-0}" | grep -qE '^[0-3]$'; then
     _pleskxml_DBG_LEVEL="${pleskxml_debug_min_level:-0}"
     _pleskxml_DBG_COUNT=0
   else
@@ -72,45 +67,36 @@ _DBG_EARLY_CHECK_MODE() {
   fi
 
   _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_DBG_LEVEL}' "
-    # This won't display if DBG level was set to zero.
+  # This won't display if DBG level was set to zero.
 }
 
 #  arg1 = severity level (1=least serious, 3=most serious)
 # By design if DBG level is 9 for a MESSAGE, the message is ALWAYS shown, this is used for _info and _err
 #  arg2 = message
 _DBG() {
-  if [ "$1" -eq 9 ] || ( [ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_DBG_LEVEL" ] ); then
+  if [ "$1" -eq 9 ] || ([ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_DBG_LEVEL" ]); then
     case $1 in
-      1)  _pleskxml_severity='INFO'
-        ;;
-      2)  _pleskxml_severity='WARN'
-        ;;
-      3)  _pleskxml_severity='ERR'
-        ;;
-      9)  _pleskxml_severity='_ACME.SH'
-        ;;
+      1) _pleskxml_severity='INFO' ;;
+      2) _pleskxml_severity='WARN' ;;
+      3) _pleskxml_severity='ERR' ;;
+      9) _pleskxml_severity='_ACME.SH' ;;
     esac
-    _pleskxml_DBG_COUNT=$(( _pleskxml_DBG_COUNT + 1 ))
+    _pleskxml_DBG_COUNT=$((_pleskxml_DBG_COUNT + 1))
     printf '%04d DEBUG [%s]:\n%s\n\n' "$_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$2"
   fi
 }
 
-
 #  arg1 = severity level (1=least serious, 3=most serious)
 #  arg2 = message (vardump will be appended)
 _DBG_VARDUMP() {
-  _DBG "$1" "$( printf '%s: 1st lines of current defined variables are now:\n%s\n\n' "${2:-NO_FURTHER_MSG}" "$( set | grep '_pleskxml' | sort )" )"
+  _DBG "$1" "$(printf '%s: 1st lines of current defined variables are now:\n%s\n\n' "${2:-NO_FURTHER_MSG}" "$(set | grep '_pleskxml' | sort)")"
 }
-
 
 _DBG_ERR_TRAP() {
   echo "Error on line $1"
 }
 
-
-
 ############ Start of module itself ##############################
-
 
 # Trap errors and perform early check for debug mode.
 # Traps currently ignored
@@ -186,7 +172,7 @@ dns_pleskxml_add() {
     return 1
   fi
 
-  if [ "$_pleskxml_allow_insecure"  ]; then
+  if [ "$_pleskxml_allow_insecure" ]; then
     _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
   fi
 
@@ -197,11 +183,10 @@ dns_pleskxml_add() {
 
   _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
-  _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
+  _pleskxml_domain_id="$(_pleskxml_get_domain_ID "$_pleskxml_domain")"
   _pleskxml_retcode=$?
 
   _DBG_VARDUMP 2 'Call has returned'
-
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -236,8 +221,6 @@ dns_pleskxml_add() {
 
   return 0
 }
-
-
 
 # Usage: dns_pleskxml_rm _acme-challenge.domain.org "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 # Remove a TXT record after validation
@@ -278,7 +261,7 @@ dns_pleskxml_rm() {
 
   _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
-  _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
+  _pleskxml_domain_id="$(_pleskxml_get_domain_ID "$_pleskxml_domain")"
   _pleskxml_retcode=$?
 
   _DBG_VARDUMP 2 'Call has returned'
@@ -318,7 +301,6 @@ dns_pleskxml_rm() {
 
 ####################  Define private functions ##################################
 
-
 ####################  Plesk related functions
 
 _pleskxml_get_variables() {
@@ -335,8 +317,8 @@ _pleskxml_get_variables() {
   # At most the check can be removed. But it needs to be able to split out a host and a domain.
 
   if printf '%s' "$_pleskxml_FQDN" | grep -iEq '^[^][/.:[:space:]^$*'\''"`-][^][/.:[:space:]^$*'\''"`]*(\.[^][/.:[:space:]^$*'\''"`_]+)+$'; then
-    _pleskxml_host="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^([^.]+)\..*$/\1/' )"
-    _pleskxml_domain="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^[^.]+\.(.*)$/\1/' )"
+    _pleskxml_host="$(printf '%s' "$_pleskxml_FQDN" | sed -E 's/^([^.]+)\..*$/\1/')"
+    _pleskxml_domain="$(printf '%s' "$_pleskxml_FQDN" | sed -E 's/^[^.]+\.(.*)$/\1/')"
   else
     _pleskxml_errors="An invalid domain name (FQDN) was supplied."
   fi
@@ -353,7 +335,6 @@ _pleskxml_get_variables() {
     _pleskxml_allow_insecure=0
     _pleskxml_uri_prefix_match='https://'
   fi
-
 
   if printf '%s' "${pleskxml_uri:-}" | grep -qiE "^${_pleskxml_uri_prefix_match}"'([a-z0-9][a-z0-9.:-]*|\[[a-f0-9][a-f0-9.:]+\])(:[0-9]{1,5})?(/|$)'; then
     # URI is "valid enough" to use, and uses https if this is mandatory (= pleskxml_allow_insecure_uri wasn't set)
@@ -390,14 +371,11 @@ _pleskxml_get_variables() {
   fi
 }
 
-
-
 # Build a cURL request for the Plesk API
 # ARGS:
 # First arg is a Plesk XML API template. Further args (up to 3 items) are substituted into it via printf
 
 _pleskxml_api_request() {
-
 
   _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
 
@@ -417,12 +395,12 @@ _pleskxml_api_request() {
 
   # Sanitise user+pw for single quote enclosure, ands build Plesk arg string
 
-  _pleskxml_user="$( printf '%s' "$_pleskxml_user" | sed "s/'/'\\''/g" )"
-  _pleskxml_pass="$( printf '%s' "$_pleskxml_pass" | sed "s/'/'\\''/g" )"
-  _pleskxml_APICMD="$( printf "$1 %0.0s%0.0s%0.0s" "$2" "$3" "$4" )"
-    # Add some %0.0s at the end of the format string in the 1st arg, to cope with ("absorb") variable number of further args
-    # otherwise this will repeat the format string which we don't want.
-    # If there weren't additional args, these will evaluate to empty strings/blank, and be harmless.
+  _pleskxml_user="$(printf '%s' "$_pleskxml_user" | sed "s/'/'\\''/g")"
+  _pleskxml_pass="$(printf '%s' "$_pleskxml_pass" | sed "s/'/'\\''/g")"
+  _pleskxml_APICMD="$(printf "$1 %0.0s%0.0s%0.0s" "$2" "$3" "$4")"
+  # Add some %0.0s at the end of the format string in the 1st arg, to cope with ("absorb") variable number of further args
+  # otherwise this will repeat the format string which we don't want.
+  # If there weren't additional args, these will evaluate to empty strings/blank, and be harmless.
 
   _pleskxml_curlargs="--anyauth \
          -X POST \
@@ -435,13 +413,13 @@ _pleskxml_api_request() {
 
   _DBG_VARDUMP 2 'About to call Plesk via cURL'
 
-  _DBG 2 "$( printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" )"
-    _pleskxml_prettyprint_result="$( eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null )"
-    _pleskxml_retcode="$?"
+  _DBG 2 "$(printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri")"
+  _pleskxml_prettyprint_result="$(eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null)"
+  _pleskxml_retcode="$?"
   _DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
   _DBG 2 "retcode = $_pleskxml_retcode"
 
- # BUGFIX TO CHECK - WILL RETCODE FROM cURL BE AVAILABLE HERE?
+  # BUGFIX TO CHECK - WILL RETCODE FROM cURL BE AVAILABLE HERE?
 
   # Abort if cURL failed
 
@@ -453,16 +431,16 @@ _pleskxml_api_request() {
 
   # OK. Next, check XML reply was OK. Start by pushing it into one line, with leading/trailing space trimmed.
 
-#  _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
-#      awk '{$1=$1};1' | \
-#      tr -d '\n' \
-#      )"
+  #  _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
+  #      awk '{$1=$1};1' | \
+  #      tr -d '\n' \
+  #      )"
 
-  _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
-      sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
-      tr -d '\n' \
-      )"
-  
+  _pleskxml_result="$(printf '%s' "$_pleskxml_prettyprint_result" \
+    | sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' \
+    | tr -d '\n'
+  )"
+
   _DBG_VARDUMP 2 'cURL succeeded, valid cURL response obtained'
 
   # Now we need to check item by item if it's OK.
@@ -479,16 +457,15 @@ _pleskxml_api_request() {
     return 1
   else
     # So far so good. Strip the <?xml> and <packet>...</packet> tags and continue
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-        sed -E 's/^<\?xml version[^>]+><packet version[^>]+>(.*)<\/packet>$/\1/' \
-        )"
+    _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+      | sed -E 's/^<\?xml version[^>]+><packet version[^>]+>(.*)<\/packet>$/\1/'
+    )"
   fi
 
   _DBG 2 "Checking <system> tags don't exist..."
 
   # <system> section found anywhere in response?
   # This usually means some kind of basic API error such as login failure, bad XML request, etc
-
 
   if printf '%s' "$_pleskxml_result" | grep -qiE '<system>.*</system>'; then
     # Error - shouldn't contain <system>...</system>. Abort
@@ -497,9 +474,7 @@ _pleskxml_api_request() {
     return 1
   fi
 
-
   _DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
-
 
   # Check results section. Most commands only have one results section.
   # But some (i.e., get all DNS records for a domain) have many results sections,
@@ -520,15 +495,15 @@ _pleskxml_api_request() {
 
   _DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
 
-  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-    sed "s/<result>/\\${_pleskxml_newline}<result>/g" | \
-    sed "s/<\/result>/<\/result>\\${_pleskxml_newline}/g" | \
-    grep '<result>' \
-     )"
+  _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+    | sed "s/<result>/\\${_pleskxml_newline}<result>/g" \
+    | sed "s/<\/result>/<\/result>\\${_pleskxml_newline}/g" \
+    | grep '<result>'
+  )"
 
   # Detect and abort if there are >1 <result> sections and we're ponly expecting 1 section.
 
-  _pleskxml_linecount=$( printf '%s\n' "$_pleskxml_result" | wc -l )
+  _pleskxml_linecount=$(printf '%s\n' "$_pleskxml_result" | wc -l)
 
   _DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
 
@@ -551,8 +526,7 @@ _pleskxml_api_request() {
     # _pleskxml_line *should* contain a single result section.
     # Check this is correct.
 
-
-# _DBG "Checking a <result> section... content is ${_pleskxml_line}"
+    # _DBG "Checking a <result> section... content is ${_pleskxml_line}"
 
     if printf '%s' "$_pleskxml_line" | grep -qiEv '^<result>.*</result>$'; then
       # Error - doesn't contain <result>...</result>. Abort
@@ -562,7 +536,7 @@ _pleskxml_api_request() {
 
     # Now strip the <results> tag and check there is precisely one <status> section and its ciontents are "ok"
 
-    _pleskxml_line="$( printf '%s' "$_pleskxml_line" | sed -E 's/^<result>(.*)<\/result>$/\1/' )"
+    _pleskxml_line="$(printf '%s' "$_pleskxml_line" | sed -E 's/^<result>(.*)<\/result>$/\1/')"
 
     if printf '%s' "$_pleskxml_line" | grep -qiEv '<status>.*</status>'; then
       # Error - doesn't contain <status>...</status>. Abort
@@ -581,9 +555,9 @@ _pleskxml_api_request() {
       return 1
     fi
 
-# _DBG "Line is OK. Looping to next line or exiting..."
+    # _DBG "Line is OK. Looping to next line or exiting..."
 
-  done << EOL
+  done <<EOL
 $_pleskxml_result
 EOL
 
@@ -591,17 +565,17 @@ EOL
 
   _DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
 
-  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-      sed -E 's/<status>ok<\/status>//g' \
-      )"
+  _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+    | sed -E 's/<status>ok<\/status>//g'
+  )"
 
   # Result is OK. Remove any redundant self-closing tags, and <data> or </data> tags, and exit
 
   _DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
 
-  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-      sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g' \
-      )"
+  _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+    | sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g'
+  )"
 
   _DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
 
@@ -610,9 +584,6 @@ EOL
   return 0
 
 }
-
-
-
 
 _pleskxml_get_domain_ID() {
 
@@ -624,7 +595,7 @@ _pleskxml_get_domain_ID() {
 
   _pleskxml_api_request "$_pleskxml_tplt_get_domain_id" "$1"
   _pleskxml_retcode=$?
-    # $1 is the domain name we wish to convert to a Plesk domain ID
+  # $1 is the domain name we wish to convert to a Plesk domain ID
 
   _DBG 2 'Returned from API request, now back in get_domain_ID()'
 
@@ -652,9 +623,9 @@ _pleskxml_get_domain_ID() {
     return 1
   else
     # So far so good. Remove the <result>...</result> section and continue
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-        sed -E 's/(^<result>|<\/result>$)//g' \
-        )"
+    _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+      | sed -E 's/(^<result>|<\/result>$)//g'
+    )"
   fi
 
   # Result should contain precisely one <filter-id> section, containing the domain name inquired.
@@ -673,9 +644,9 @@ _pleskxml_get_domain_ID() {
     return 1
   else
     # So far so good. Remove the <filter-id>...</filter-id> section and continue
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-        sed "s/<filter-id>$1<\/filter-id>//" \
-        )"
+    _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+      | sed "s/<filter-id>$1<\/filter-id>//"
+    )"
   fi
 
   # All that should be left is one section, containing <id>DOMAIN_ID</id>
@@ -691,16 +662,15 @@ _pleskxml_get_domain_ID() {
 
   # SUCCESS! Remove the surrounding <id> tag and return the value!
 
-  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-      sed -E 's/^<id>([0-9]+)<\/id>$/\1/' \
-      )"
+  _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+    | sed -E 's/^<id>([0-9]+)<\/id>$/\1/'
+  )"
 
   _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
 
   return 0
 
 }
-
 
 # 1st arg is the domain ID
 # 2nd arg (optional) is the TYPE of arg(s) to keep
@@ -716,10 +686,9 @@ _pleskxml_get_dns_records() {
 
   _pleskxml_api_request "$_pleskxml_tplt_get_dns_records" "$1"
   _pleskxml_retcode=$?
-    # $1 is the Plesk internal domain ID for the domain
+  # $1 is the Plesk internal domain ID for the domain
 
   _DBG 2 'Returned from API request, now back in get_txt_records()'
-
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -733,9 +702,9 @@ _pleskxml_get_dns_records() {
   _DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
 
   if [ -n "${2:-}" ]; then
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-        grep "<type>$2</type>" \
-        )"
+    _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+      | grep "<type>$2</type>"
+    )"
     _DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
   else
     _DBG 2 'Not filtering DNS records. All records will be returned.'
@@ -744,8 +713,6 @@ _pleskxml_get_dns_records() {
   _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
   return 0
 }
-
-
 
 _pleskxml_add_txt_record() {
 
@@ -756,9 +723,9 @@ _pleskxml_add_txt_record() {
   _pleskxml_api_request "$_pleskxml_tplt_add_txt_record" "$1" "$2" "$3"
   _pleskxml_retcode=$?
 
-    # $1 is the Plesk internal domain ID for the domain
-    # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
-    # $3 is the TXT record value
+  # $1 is the Plesk internal domain ID for the domain
+  # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
+  # $3 is the TXT record value
 
   _DBG 2 'Returned from API request, now back in add_txt_record()'
 
@@ -781,9 +748,9 @@ _pleskxml_add_txt_record() {
   # SUCCESS! Remove the surrounding <result><id> tags and return the value!
   # (although we don't actually use it!
 
-  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-      sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/" \
-      )"
+  _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+    | sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/"
+  )"
 
   _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
 
@@ -799,7 +766,7 @@ _pleskxml_rmv_dns_record() {
   _pleskxml_api_request "$_pleskxml_tplt_rmv_dns_record" "$1"
   _pleskxml_retcode=$?
 
-    # $1 is the Plesk internal domain ID for the TXT record
+  # $1 is the Plesk internal domain ID for the TXT record
 
   _DBG 2 'Returned from API request, now back in rmv_dns_record()'
 
@@ -816,21 +783,18 @@ _pleskxml_rmv_dns_record() {
   return 0
 }
 
-
 # 1st arg = domain ID
 # 2nd arg = host that the record exists for
 # 3rd arg = value of TXT record string to be found and removed
 _pleskxml_rmv_txt_record() {
 
-
   _DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
 
   _pleskxml_get_dns_records "$1" 'TXT'
   _pleskxml_retcode=$?
-    # $1 is the Plesk internal domain ID for the domain
+  # $1 is the Plesk internal domain ID for the domain
 
   _DBG 2 'Returned from API request, now back in rmv_txt_record()'
-
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -844,15 +808,15 @@ _pleskxml_rmv_txt_record() {
 
   _DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
 
-  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-      grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." | \
-      grep -F "<value>${3:-<NON_MATCHING_GARBAGE>}</value>" | \
-      sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
-      tr -d '\n' \
-      )"
-    # Run 2 separate GREP filters, because the host and value order isn't mandatory in the API return data
-    # ands this avoids regex and escaping which is easier
-    # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
+  _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+    | grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." \
+    | grep -F "<value>${3:-<NON_MATCHING_GARBAGE>}</value>" \
+    | sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' \
+32m    | tr -d '\n'
+  )"
+  # Run 2 separate GREP filters, because the host and value order isn't mandatory in the API return data
+  # ands this avoids regex and escaping which is easier
+  # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
 
   _DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
 
@@ -873,9 +837,9 @@ _pleskxml_rmv_txt_record() {
 
   # If we get here, there was a single TXT record match, so we delete it.
 
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-        sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/' \
-        )"
+  _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
+    | sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/'
+  )"
 
   _DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
 
@@ -895,21 +859,19 @@ _pleskxml_rmv_txt_record() {
   return 0
 }
 
-
 exit
 
 # ---------------------- TEST CODE ------------------------------
 
-
 # defined by user
-  pleskxml_uri="https://plesk.XXXXX.net:8443/enterprise/control/agent.php"
-  pleskxml_user="XXXXX"
-  pleskxml_pass="XXXXX"
-  pleskxml_debug_min_level=3
+pleskxml_uri="https://plesk.XXXXX.net:8443/enterprise/control/agent.php"
+pleskxml_user="XXXXX"
+pleskxml_pass="XXXXX"
+pleskxml_debug_min_level=3
 
 # defined from args by module
-  _pleskxml_FQDN="_acme_challenge.XXXXX.com"
-  _pleskxml_TXT_string='~test~string~'
+_pleskxml_FQDN="_acme_challenge.XXXXX.com"
+_pleskxml_TXT_string='~test~string~'
 
 printf '\n\n\n\n======================================================================== START OF RUN\n\n'
 
@@ -920,25 +882,25 @@ _DBG_EARLY_CHECK_MODE
 _DBG 3 'Debug mode done. Now testing _pleskxml_get_variables()'
 
 _pleskxml_get_variables
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG 3 '==============================================================='
 
 _DBG 3 'Testing _pleskxml_get_domain_ID()'
 _pleskxml_get_domain_ID "atticflat.uk"
 
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG_VARDUMP 2
 
 _DBG 3 '==============================================================='
 
-test_string="TEST STRING ADDED @ $( date )"
+test_string="TEST STRING ADDED @ $(date)"
 
 _DBG 3 "Testing add a TXT string: '$test_string' "
 _pleskxml_add_txt_record 874 '_test_subdomain' "$test_string"
 
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG_VARDUMP 2
 
@@ -947,7 +909,7 @@ _DBG 3 '==============================================================='
 _DBG 3 'Testing get DNS records (ALL)'
 _pleskxml_get_dns_records 874
 
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG_VARDUMP 2
 
@@ -956,7 +918,7 @@ _DBG 3 '==============================================================='
 _DBG 3 'Testing get DNS records (TXT ONLY)'
 _pleskxml_get_dns_records 874 TXT
 
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG_VARDUMP 2
 
@@ -965,7 +927,7 @@ _DBG 3 '==============================================================='
 _DBG 3 'Testing rmv a TXT string'
 _pleskxml_rmv_txt_record 874 '_test_subdomain' "$test_string"
 
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG_VARDUMP 2
 
@@ -974,7 +936,7 @@ _DBG 3 '==============================================================='
 _DBG 3 'Re-testing get DNS records (TXT ONLY) after TXT string removal'
 _pleskxml_get_dns_records 874 TXT
 
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG_VARDUMP 2
 
@@ -983,7 +945,7 @@ _DBG 3 '==============================================================='
 _DBG 3 'Testing rmv a TXT string, with a non-matching string'
 _pleskxml_rmv_txt_record 874 '_test_subdomain' 'JUNKegqw4bw4bb2'
 
-_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
 
 _DBG_VARDUMP 2
 

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -7,22 +7,22 @@
 
 # v0.1 alpha - 2018-08-13
 
-# This DNS01 method allows acme.sh to set DNS TXT records 
+# This DNS01 method allows acme.sh to set DNS TXT records
 # using the Plesk XML API described at:
 #   https://docs.plesk.com/en-US/12.5/api-rpc/about-xml-api.28709
 #   and more specifically: https://docs.plesk.com/en-US/12.5/api-rpc/reference.28784
 
 
 # This may be needed if the DNS provider doesn't make the standard Plesk API available to a user.
-# As a result, Plesk can't be configured using usual means or RFC1236. But the XML API is often 
+# As a result, Plesk can't be configured using usual means or RFC1236. But the XML API is often
 # still left accessible, and is well documented, so it can be used instead, for acme.sh purposes.
 
 
 # API NOTES:
 
 # 1) The API uses a user/password combination. It should therefore require cURL over HTTPS
-#    with a MAXIMALLY SECURE TLS CIPHER AND GOOD CERT + REVOCATION CHECKS ON THE API URI, 
-#    in (almost) all cases. 
+#    with a MAXIMALLY SECURE TLS CIPHER AND GOOD CERT + REVOCATION CHECKS ON THE API URI,
+#    in (almost) all cases.
 
 #    Acceptable/valid ciphers and certificate checks can be specified via optional cURL variables (see below).
 #    Note that edge cases may exist where SSL is not yet set up
@@ -30,7 +30,7 @@
 
 # 2) --anyauth is used with cURL, to ensure the highest available level of encryption.
 
-# 3) The API references domains by a domain ID, when manipulating records. So the code must 
+# 3) The API references domains by a domain ID, when manipulating records. So the code must
 #    initially convert domain names (string) to Plesk domain IDs (numeric).
 
 
@@ -41,7 +41,7 @@
 #     export pleskxml_uri="https://www.plesk_uri.org:8443/enterprise/control/agent.php"
 #                         (or something similar)
 #     export pleskxml_user="johndoe"
-#     export pleskxml_pass="kj8we8dej38e8d#q0q3!!!qa"
+#     export pleskxml_pass="XXXXX"
 
 
 # OPTIONAL VARIABLES:
@@ -62,7 +62,7 @@
 ############  Before anything else, define dedug functions to be sure they are detected even if while testing #####################
 
 _DBG_EARLY_CHECK_MODE() {
-    
+
     if printf '%s' "${pleskxml_debug_min_level:-0}" | grep -qE '^[0-3]$' ; then
         _pleskxml_DBG_LEVEL="${pleskxml_debug_min_level:-0}"
         _pleskxml_DBG_COUNT=0
@@ -72,7 +72,7 @@ _DBG_EARLY_CHECK_MODE() {
     fi
 
     _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_DBG_LEVEL}' "
-        # This won't display if DBG level was set to zero.    
+        # This won't display if DBG level was set to zero.
 }
 
 #  arg1 = severity level (1=least serious, 3=most serious)
@@ -130,7 +130,7 @@ _pleskxml_newline='
 '
 
 
-# Plesk XML templates. 
+# Plesk XML templates.
 #   Note ALL TEMPLATES MUST HAVE EXACTLY 3 %s PLACEHOLDERS
 #   (otherwise printf repeats the string causing the API call to fail)
 
@@ -163,24 +163,23 @@ _pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-
 
 dns_pleskxml_add() {
 
-
-_DBG 2 "Entered dns_pleskxml_add($*)..."
+    _DBG 2 "Entered dns_pleskxml_add($*)..."
 
     _pleskxml_FQDN=$1
     _pleskxml_TXT_string=$2
-    
+
     # validate variables set by user.
     # If valid, then matching internal variables will be set with the appropriate checked values
     # Otherwise exit with an error
-    
+
     _info "Plesk XML: Trying to add a DNS TXT record for acme validation."
     _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
     _info "Plesk XML: Checking login and other variables supplied by user"
 
     _pleskxml_get_variables
     _pleskxml_retcode=$?
-    
-_DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
+
+    _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
         _err "$_pleskxml_errors"
@@ -190,18 +189,18 @@ _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
     if [ "$_pleskxml_allow_insecure"  ]; then
         _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
     fi
-    
+
     # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
 
     _info "Plesk XML: Variables loaded."
     _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-_DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
+    _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
     _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
     _pleskxml_retcode=$?
 
-_DBG_VARDUMP 2 'Call has returned'
+    _DBG_VARDUMP 2 'Call has returned'
 
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
@@ -212,17 +211,17 @@ _DBG_VARDUMP 2 'Call has returned'
 
     # OK, valid response containing a valid domain ID must have been found
     # If not we should have got an error.
-    
+
     # Try to add the TXT record
 
-_DBG 2 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+    _DBG 2 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
     _info "Plesk XML: Trying to add TXT record to domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'. The TXT string is: '$_pleskxml_TXT_string'."
 
     _pleskxml_add_dns_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
     _pleskxml_retcode=$?
 
-_DBG_VARDUMP 2 'Call has returned'
+    _DBG_VARDUMP 2 'Call has returned'
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -233,7 +232,7 @@ _DBG_VARDUMP 2 'Call has returned'
     _info 'An ACME Challenge TXT record for '"$_pleskxml_domain"' was added to Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
     _info "(TO CHECK?: Note that all subdomains under this domain uses the same TXT record.) <-- MAY NOT BE NEEDED"
 
-_DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
+    _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
 
     return 0
 }
@@ -245,15 +244,15 @@ _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
 
 dns_pleskxml_rm() {
 
-_DBG 2 "Entered dns_pleskxml_rm($*)..."
+    _DBG 2 "Entered dns_pleskxml_rm($*)..."
 
     _pleskxml_FQDN=$1
     _pleskxml_TXT_string=$2
-    
+
     # validate variables set by user.
     # If valid, then matching internal variables will be set with the appropriate checked values
     # Otherwise exit with an error
-    
+
     _info "Plesk XML: Trying to remove a recently-added DNS TXT record for following acme validation."
     _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
     _info "Plesk XML: Checking login and other variables supplied by user"
@@ -261,7 +260,7 @@ _DBG 2 "Entered dns_pleskxml_rm($*)..."
     _pleskxml_get_variables
     _pleskxml_retcode=$?
 
-_DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
+    _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
         _err "$_pleskxml_errors"
@@ -271,18 +270,18 @@ _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
     if [ "$_pleskxml_allow_insecure" ]; then
         _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
     fi
-    
+
     # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
 
     _info "Plesk XML: Variables loaded."
     _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-_DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
+    _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
     _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
     _pleskxml_retcode=$?
 
-_DBG_VARDUMP 2 'Call has returned'
+    _DBG_VARDUMP 2 'Call has returned'
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -292,17 +291,17 @@ _DBG_VARDUMP 2 'Call has returned'
 
     # OK, valid response containing a valid domain ID must have been found
     # If not we should have got an error.
-    
+
     # Try to remove the TXT record. First step - get all TXT records
 
     _info "Plesk XML: Trying to remove TXT record from domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'."
 
-_DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+    _DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
     _pleskxml_rmv_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
     _pleskxml_retcode=$?
 
-_DBG_VARDUMP 2 'Call has returned'
+    _DBG_VARDUMP 2 'Call has returned'
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -312,7 +311,7 @@ _DBG_VARDUMP 2 'Call has returned'
 
     _info 'A TXT record for '"$_pleskxml_domain"' was removed from Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
 
-_DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
+    _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
 
     return 0
 }
@@ -324,14 +323,14 @@ _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
 
 _pleskxml_get_variables() {
 
-_DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
+    _DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
 
     _pleskxml_errors=''
 
     # The Plesk XML API needs the base domain (mydomain.com) and host (_acme_challenge) split out from the FQDN
     # supplied to this module, to manage the relevant DNS records
     # We assume ACME.SH does most of the validation, but even so, let's check some basic character compliance.
-    # Not checking just [a-z0-9] since the FQDN could be unicode, but this should be reasonably sane. 
+    # Not checking just [a-z0-9] since the FQDN could be unicode, but this should be reasonably sane.
     # If not, it'll be over-cautious and block unicode based on bytes, and need fixing.
     # At most the check can be removed. But it needs to be able to split out a host and a domain.
 
@@ -343,7 +342,7 @@ _DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
     fi
 
     # Now process other variables
-    
+
     _pleskxml_allow_insecure="${pleskxml_allow_insecure_uri:-no}"
     if [ "$_pleskxml_allow_insecure" = "yes" ] || [ "$_pleskxml_allow_insecure" = "Yes" ] || [ "$_pleskxml_allow_insecure" = "YES" ]; then
         # Allow insecure (non-SSL) URI for Plesk. "s" is optional within the "https" URI
@@ -354,7 +353,7 @@ _DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
         _pleskxml_allow_insecure=0
         _pleskxml_uri_prefix_match='https://'
     fi
-    
+
 
     if printf '%s' "${pleskxml_uri:-}" | grep -qiE "^${_pleskxml_uri_prefix_match}"'([a-z0-9][a-z0-9.:-]*|\[[a-f0-9][a-f0-9.:]+\])(:[0-9]{1,5})?(/|$)'; then
         # URI is "valid enough" to use, and uses https if this is mandatory (= pleskxml_allow_insecure_uri wasn't set)
@@ -362,7 +361,7 @@ _DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
     else
         _pleskxml_errors="$_pleskxml_errors"'\nBad or unacceptable URI (If non-SSL HTTP is required, did you set "pleskxml_allow_insecure_uri"?).\nYou should set and export '"$pleskxml_uri"', containing the URI for your Plesk XML API.\nThe URI usually looks like this: https://my_plesk_uri.tld:8443'
     fi
-    
+
     if printf '%s' "${pleskxml_user:-}" | grep -qiE '^[a-z0-9@%._-]+$'; then
         # USER is "valid enough" to use - Plesk doesn't stipulate valid chars, but thewse are probably "safe enough". We will find out if they aren't, the hard way :)
         # Note, we cannot assume "safe" characters when we use this value!
@@ -378,15 +377,15 @@ _DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
     else
         _pleskxml_errors="$_pleskxml_errors"'\nEmpty USER PASSWORD for Plesk authentication. You should set and export '"$pleskxml_pass."
     fi
-    
+
     # Ensure if not supplied, optional curl args are an empty string
     _pleskxml_optional_curl_args="${pleskxml_optional_curl_args:-}"
 
     if [ -n "$_pleskxml_errors" ]; then
-_DBG_VARDUMP 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
+        _DBG_VARDUMP 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
         return 1
     else
-_DBG_VARDUMP 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
+        _DBG_VARDUMP 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
         return 0
     fi
 }
@@ -400,7 +399,7 @@ _DBG_VARDUMP 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
 _pleskxml_api_request() {
 
 
-_DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
+    _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
 
     _pleskxml_errors=''
     _pleskxml_result=''
@@ -409,7 +408,7 @@ _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_ne
 
     # Of all the API commands we use, just one of them can return multiple results sections
     # so the validation process after cURL returns, will differ for that case.....
-    
+
     if [ "$1" = "$_pleskxml_tplt_get_dns_records" ]; then
         _pleskxml_multiple_results_allowed=1
     else
@@ -434,24 +433,24 @@ _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_ne
                -d '${_pleskxml_APICMD}' \
                ${_pleskxml_optional_curl_args}"
 
-_DBG_VARDUMP 2 'About to call Plesk via cURL'
+    _DBG_VARDUMP 2 'About to call Plesk via cURL'
 
-_DBG 2 "$( printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" )"
+    _DBG 2 "$( printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" )"
         _pleskxml_prettyprint_result="$( eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null )"
         _pleskxml_retcode="$?"
-_DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
-_DBG 2 "retcode = $_pleskxml_retcode"
+    _DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
+    _DBG 2 "retcode = $_pleskxml_retcode"
 
  # BUGFIX TO CHECK - WILL RETCODE FROM cURL BE AVAILABLE HERE?
 
     # Abort if cURL failed
-    
+
     if [ $_pleskxml_retcode -ne 0 ]; then
         _pleskxml_errors="Exiting due to cURL error when querying Plesk XML API. The cURL return code was: $_pleskxml_retcode."
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
-    
+
     # OK. Next, check XML reply was OK. Start by pushing it into one line, with leading/trailing space trimmed.
 
 #    _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
@@ -463,20 +462,20 @@ _DBG 2 "$_pleskxml_errors"
             sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
             tr -d '\n' \
             )"
-
-_DBG_VARDUMP 2 'cURL succeeded, valid cURL response obtained'
-
-    # Now we need to check item by item if it's OK. 
-    # As we go, we will strip out "known OK" stuff to leave the core reply.
     
+    _DBG_VARDUMP 2 'cURL succeeded, valid cURL response obtained'
+
+    # Now we need to check item by item if it's OK.
+    # As we go, we will strip out "known OK" stuff to leave the core reply.
+
     # XML header and packet version?
 
-_DBG 2 'Checking <?xml> and <packet> tags exist...'
+    _DBG 2 'Checking <?xml> and <packet> tags exist...'
 
     if printf '%s' "$_pleskxml_result" | grep -qiEv '^<\?xml version=[^>]+><packet version=[^>]+>.*</packet>$'; then
         # Error - should have <?xml><packet>...</packet>. Abort
         _pleskxml_errors="Error when querying Plesk XML API. The API did not return a valid XML response. The response was:${_pleskxml_newline}${_pleskxml_prettyprint_result}${_pleskxml_newline}The collapsed version was:${_pleskxml_newline}'${_pleskxml_result}'${_pleskxml_newline}"
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     else
         # So far so good. Strip the <?xml> and <packet>...</packet> tags and continue
@@ -485,41 +484,41 @@ _DBG 2 "$_pleskxml_errors"
                 )"
     fi
 
-_DBG 2 "Checking <system> tags don't exist..."
+    _DBG 2 "Checking <system> tags don't exist..."
 
     # <system> section found anywhere in response?
     # This usually means some kind of basic API error such as login failure, bad XML request, etc
-    
+
 
     if printf '%s' "$_pleskxml_result" | grep -qiE '<system>.*</system>'; then
         # Error - shouldn't contain <system>...</system>. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The result contained a <system> tag.\nThis usually indicates an invalid login, badly formatted API request or other error. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
 
-_DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
+    _DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
 
-    
-    # Check results section. Most commands only have one results section. 
+
+    # Check results section. Most commands only have one results section.
     # But some (i.e., get all DNS records for a domain) have many results sections,
     # and we will need to check each <results>...</results> section separately.
     # So this gets a bit messy, especially as we don't have non-greedy regex
     # and we will have to work around that as well.
 
     # For this, we will split the string up again with exactly 1 <result> section per line.
-    # We check there is at least one result section. Then we add newlines before and after 
+    # We check there is at least one result section. Then we add newlines before and after
     # any <result>...</result> and ignore any lines that don't contain '<result>'.
 
     if printf '%s' "$_pleskxml_result" | grep -qiEv '<result>.*</result>'; then
         # Error - doesn't contain <result>...</result>. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The result did not contain a <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
-_DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
+    _DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
 
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
         sed "s/<result>/\\${_pleskxml_newline}<result>/g" | \
@@ -528,30 +527,30 @@ _DBG 2 'Found at least 1 <result> section. Splitting each result section to a se
          )"
 
     # Detect and abort if there are >1 <result> sections and we're ponly expecting 1 section.
-    
+
     _pleskxml_linecount=$( printf '%s\n' "$_pleskxml_result" | wc -l )
 
-_DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
+    _DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
 
-_DBG_VARDUMP 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
-    
+    _DBG_VARDUMP 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
+
     if [ $_pleskxml_multiple_results_allowed -eq 0 ] && [ "$_pleskxml_linecount" -gt 1 ]; then
         # Error - contains multiple <result> sections. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The result contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
-_DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
-    
-    # Loop through each <result> section, checking every line has exactly one result section, 
+    _DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
+
+    # Loop through each <result> section, checking every line has exactly one result section,
     # containing exactly one status section, which contains <status>ok</status>
 
     while IFS= read -r _pleskxml_line; do
 
         # _pleskxml_line *should* contain a single result section.
         # Check this is correct.
-        
+
 
 # _DBG "Checking a <result> section... content is ${_pleskxml_line}"
 
@@ -560,25 +559,25 @@ _DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has stat
             _pleskxml_errors='Error when querying Plesk XML API. A <result> section was not found where expected.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
             return 1
         fi
-    
+
         # Now strip the <results> tag and check there is precisely one <status> section and its ciontents are "ok"
-        
+
         _pleskxml_line="$( printf '%s' "$_pleskxml_line" | sed -E 's/^<result>(.*)<\/result>$/\1/' )"
 
         if printf '%s' "$_pleskxml_line" | grep -qiEv '<status>.*</status>'; then
             # Error - doesn't contain <status>...</status>. Abort
             _pleskxml_errors='Error when querying Plesk XML API. A <result> section did not contain a <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+            _DBG 2 "$_pleskxml_errors"
             return 1
         elif printf '%s' "$_pleskxml_line" | grep -qiE '<status>.*</status>.*<status>'; then
             # Error - contains <status>...</status>...<status>. Abort
             _pleskxml_errors='Error when querying Plesk XML API. A <result> section contained more than one <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+            _DBG 2 "$_pleskxml_errors"
             return 1
         elif printf '%s' "$_pleskxml_line" | grep -qiEv '<status>ok</status>'; then
             # Error - doesn't contain <status>ok</status>. Abort
             _pleskxml_errors='Error when querying Plesk XML API. A <status> tag did not contain "<status>ok</status>". The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+            _DBG 2 "$_pleskxml_errors"
             return 1
         fi
 
@@ -590,7 +589,7 @@ EOL
 
     # So far so good. Remove all <status>ok</status> sections as they're checked now.
 
-_DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
+    _DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
 
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
             sed -E 's/<status>ok<\/status>//g' \
@@ -598,18 +597,18 @@ _DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status
 
     # Result is OK. Remove any redundant self-closing tags, and <data> or </data> tags, and exit
 
-_DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
+    _DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
 
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
             sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g' \
             )"
 
-_DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
+    _DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
 
-_DBG_VARDUMP 2 'Successfully exiting Plesk XML API function'
+    _DBG_VARDUMP 2 'Successfully exiting Plesk XML API function'
 
     return 0
-    
+
 }
 
 
@@ -617,39 +616,39 @@ _DBG_VARDUMP 2 'Successfully exiting Plesk XML API function'
 
 _pleskxml_get_domain_ID() {
 
-_DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
+    _DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
 
     # Call cURL to convert a domain name to a plesk domain ID.
 
-_DBG 2 'About to make API request (domain name -> domain ID)'
+    _DBG 2 'About to make API request (domain name -> domain ID)'
 
     _pleskxml_api_request "$_pleskxml_tplt_get_domain_id" "$1"
     _pleskxml_retcode=$?
         # $1 is the domain name we wish to convert to a Plesk domain ID
-    
-_DBG 2 'Returned from API request, now back in get_domain_ID()'
+
+    _DBG 2 'Returned from API request, now back in get_domain_ID()'
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
     # OK, we should have a domain ID. Let's check and return it if so.
-    
+
     # Result should comprise precisely one <result> section
-    
-_DBG 2 'Testing API return data for one <result> and removing if so'
+
+    _DBG 2 'Testing API return data for one <result> and removing if so'
 
     if printf '%s' "$_pleskxml_result" | grep -qiEv '^<result>.*</result>$'; then
         # Error - doesn't comprise <result>DOMAINNAME</result>. Something's wrong. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The API did not comprise a <result> section containing all other data.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     elif printf '%s' "$_pleskxml_result" | grep -qiE '<result>.*<result>'; then
         # Error - contains <result>...</result>...<result>. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     else
         # So far so good. Remove the <result>...</result> section and continue
@@ -659,18 +658,18 @@ _DBG 2 "$_pleskxml_errors"
     fi
 
     # Result should contain precisely one <filter-id> section, containing the domain name inquired.
-    
-_DBG 2 'Testing API return data for one <filter-id> and removing if so'
+
+    _DBG 2 'Testing API return data for one <filter-id> and removing if so'
 
     if printf '%s' "$_pleskxml_result" | grep -qiv "<filter-id>$1</filter-id>"; then
         # Error - doesn't contain <filter-id>DOMAINNAME</filter-id>. Something's wrong. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <filter-id> section containing the domain name.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     elif printf '%s' "$_pleskxml_result" | grep -qiE '<filter-id>.*<filter-id>'; then
         # Error - contains <filter-id>...</filter-id>...<filter-id>. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <filter-id> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     else
         # So far so good. Remove the <filter-id>...</filter-id> section and continue
@@ -680,25 +679,25 @@ _DBG 2 "$_pleskxml_errors"
     fi
 
     # All that should be left is one section, containing <id>DOMAIN_ID</id>
-    
-_DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
+
+    _DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
 
     if printf '%s' "$_pleskxml_result" | grep -qiEv '^<id>[0-9]+</id>$'; then
         # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <id>[NUMERIC_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
-    
+
     # SUCCESS! Remove the surrounding <id> tag and return the value!
 
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
             sed -E 's/^<id>([0-9]+)<\/id>$/\1/' \
             )"
 
-_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
+    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
 
-    return 0    
+    return 0
 
 }
 
@@ -709,41 +708,40 @@ _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
 
 _pleskxml_get_dns_records() {
 
-_DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
+    _DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
 
     # First, we need to get all DNS records, and check the list is valid
 
-_DBG 2 'About to make API request (get DNS records)'
+    _DBG 2 'About to make API request (get DNS records)'
 
     _pleskxml_api_request "$_pleskxml_tplt_get_dns_records" "$1"
     _pleskxml_retcode=$?
         # $1 is the Plesk internal domain ID for the domain
-    
-_DBG 2 'Returned from API request, now back in get_txt_records()'
+
+    _DBG 2 'Returned from API request, now back in get_txt_records()'
 
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
     # OK, we should have a <result> section containing a list of DNS records.
     # Now keep only the TXT records
 
-
-_DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+    _DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
 
     if [ -n "${2:-}" ]; then
         _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
                 grep "<type>$2</type>" \
                 )"
-_DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+        _DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
     else
-_DBG 2 'Not filtering DNS records. All records will be returned.'
+        _DBG 2 'Not filtering DNS records. All records will be returned.'
     fi
-    
-_DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
+
+    _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
     return 0
 }
 
@@ -751,9 +749,9 @@ _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
 
 _pleskxml_add_txt_record() {
 
-_DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
+    _DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
 
-_DBG 2 'About to make API request (add TXT record)'
+    _DBG 2 'About to make API request (add TXT record)'
 
     _pleskxml_api_request "$_pleskxml_tplt_add_txt_record" "$1" "$2" "$3"
     _pleskxml_retcode=$?
@@ -762,24 +760,24 @@ _DBG 2 'About to make API request (add TXT record)'
         # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
         # $3 is the TXT record value
 
-_DBG 2 'Returned from API request, now back in add_txt_record()'
-    
+    _DBG 2 'Returned from API request, now back in add_txt_record()'
+
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
     # OK, we should have added a TXT record. Let's check and return success if so.
     # All that should be left in the result, is one section, containing <result><id>PLESK_NEW_DNS_RECORD_ID</id></result>
-    
+
     if printf '%s' "$_pleskxml_result" | grep -qivE '^<result><id>[0-9]+</id></result>$'; then
         # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
         _pleskxml_errors='Error when calling Plesk XML API. The API did not contain the expected <id>[PLESK_NEW_DNS_RECORD_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
-    
+
     # SUCCESS! Remove the surrounding <result><id> tags and return the value!
     # (although we don't actually use it!
 
@@ -787,35 +785,35 @@ _DBG 2 "$_pleskxml_errors"
             sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/" \
             )"
 
-_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
+    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
 
-    return 0    
+    return 0
 }
 
 _pleskxml_rmv_dns_record() {
 
-_DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
+    _DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
 
-_DBG 2 'About to make API request (rmv TXT record)'
+    _DBG 2 'About to make API request (rmv TXT record)'
 
     _pleskxml_api_request "$_pleskxml_tplt_rmv_dns_record" "$1"
     _pleskxml_retcode=$?
 
         # $1 is the Plesk internal domain ID for the TXT record
 
-_DBG 2 'Returned from API request, now back in rmv_dns_record()'
-    
+    _DBG 2 'Returned from API request, now back in rmv_dns_record()'
+
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
     # OK, we should have removed a TXT record. If it failed, there wouldn't have been a "status:ok" above
 
-_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
+    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
 
-    return 0    
+    return 0
 }
 
 
@@ -825,18 +823,18 @@ _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
 _pleskxml_rmv_txt_record() {
 
 
-_DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
+    _DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
 
     _pleskxml_get_dns_records "$1" 'TXT'
     _pleskxml_retcode=$?
         # $1 is the Plesk internal domain ID for the domain
-    
-_DBG 2 'Returned from API request, now back in rmv_txt_record()'
+
+    _DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
@@ -844,7 +842,7 @@ _DBG 2 "$_pleskxml_errors"
     # Now we need to find our desired record in it (if it exists).
     # and might as well collapse any successful matches to a signle line for line-count purposes at the same time
 
-_DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
+    _DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
 
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
             grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." | \
@@ -856,19 +854,19 @@ _DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<N
         # ands this avoids regex and escaping which is easier
         # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
 
-_DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
+    _DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
 
     if printf '%s' "$_pleskxml_result" | grep -qiE "<result>.*<result>"; then
         # Error - contains <result>...</result>...<result>. Abort
         _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
-    
+
     if printf '%s\n' "$_pleskxml_result" | grep -qiv "<result>"; then
         # No matching TXT records, so we're done.
         _info "Couldn't find a TXT record matching the requested host/value. Not an error, but a concern..."
-_DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
+        _DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
         _pleskxml_result=''
         return 0
     fi
@@ -879,22 +877,22 @@ _DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as no
                 sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/' \
                 )"
 
-_DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
+    _DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
 
     _pleskxml_rmv_dns_record "$_pleskxml_result"
     _pleskxml_retcode=$?
-    
-_DBG 2 'Returned from API request, now back in rmv_txt_record()'
+
+    _DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
     if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
         # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-_DBG 2 "$_pleskxml_errors"
+        _DBG 2 "$_pleskxml_errors"
         return 1
     fi
 
-_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
+    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
 
-    return 0    
+    return 0
 }
 
 
@@ -903,16 +901,16 @@ exit
 # ---------------------- TEST CODE ------------------------------
 
 
-# defined by user 
+# defined by user
     pleskxml_uri="https://plesk.XXXXX.net:8443/enterprise/control/agent.php"
     pleskxml_user="XXXXX"
     pleskxml_pass="XXXXX"
     pleskxml_debug_min_level=3
-    
+
 # defined from args by module
     _pleskxml_FQDN="_acme_challenge.XXXXX.com"
     _pleskxml_TXT_string='~test~string~'
-    
+
 printf '\n\n\n\n======================================================================== START OF RUN\n\n'
 
 _info 'Checking debug mode...'

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -121,26 +121,26 @@ _pleskxml_newline='
 #   (otherwise printf repeats the string causing the API call to fail)
 
 _pleskxml_tplt_get_domain_id="<packet><webspace><get><filter><name>%s</name></filter><dataset></dataset></get></webspace></packet>"
-  # Convert domain name to a Plesk internal domain ID
-  # Args:
-  #   the domain name to query
+#   Convert domain name to a Plesk internal domain ID
+#   Args:
+#     the domain name to query
 
 _pleskxml_tplt_add_txt_record="<packet><dns><add_rec><site-id>%s</site-id><type>TXT</type><host>%s</host><value>%s</value></add_rec></dns></packet>"
-  # Adds a TXT record to a domain
-  # Args:
-  #   the Plesk internal domain ID for the domain
-  #   the "host" entry within the domain, to add this to (eg '_acme_challenge')
-  #   the TXT record value
+#   Adds a TXT record to a domain
+#   Args:
+#     the Plesk internal domain ID for the domain
+#     the "host" entry within the domain, to add this to (eg '_acme_challenge')
+#     the TXT record value
 
 _pleskxml_tplt_rmv_dns_record="<packet><dns><del_rec><filter><id>%s</id></filter></del_rec></dns></packet>"
-  # Adds a TXT record to a domain
-  # Args:
-  #   the Plesk internal ID for the dns record to delete
+#   Adds a TXT record to a domain
+#   Args:
+#     the Plesk internal ID for the dns record to delete
 
 _pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-id></filter></get_rec></dns></packet>"
-  # Gets all DNS records for a Plesk domain ID
-  # Args:
-  #   the domain id to query
+#   Gets all DNS records for a Plesk domain ID
+#   Args:
+#     the domain id to query
 
 
 ############  Define public functions #####################
@@ -812,7 +812,7 @@ _pleskxml_rmv_txt_record() {
     | grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." \
     | grep -F "<value>${3:-<NON_MATCHING_GARBAGE>}</value>" \
     | sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' \
-32m    | tr -d '\n'
+    | tr -d '\n'
   )"
   # Run 2 separate GREP filters, because the host and value order isn't mandatory in the API return data
   # ands this avoids regex and escaping which is easier

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -92,7 +92,7 @@ _pleskxml_DBG() {
 # Credit to/based on Stephanie Chazelas' snippet:
 # https://unix.stackexchange.com/questions/462280/listing-shell-variables-with-a-fixed-prefix
 _pleskxml_DBG_GET_VAR() {
-  case "$1" in (_pleskxml_*)
+  case "$1" in _pleskxml_*)
     __pleskxml_vars="${__pleskxml_vars}$(printf '%s' "$1" | sed 's/^_pleskxml_DBG_GET_VAR //' | sed -E '1 s~^([^=]+)=~    \1 --> "~')\"${_pleskxml_newline}"
   esac
   # Old code in case:
@@ -104,7 +104,7 @@ _pleskxml_DBG_GET_VAR() {
 # arg1 = severity level (1=least serious, 3=most serious)
 _pleskxml_DBG_VARDUMP() {
   __pleskxml_vars=''
-  eval "$( set | sed 's/^/_pleskxml_DBG_GET_VAR /' )"
+  eval "$(set | sed 's/^/_pleskxml_DBG_GET_VAR /')"
   _pleskxml_DBG "$1" "$(printf 'Currently defined _pleskxml_* variables are:\n%s\n\n' "$__pleskxml_vars")"
   #  Old code in case:
   #  _pleskxml_DBG "$1" "$(printf '1st lines of current defined variables are now:\n%s\n\n' "$(set | grep '_pleskxml' | sort)")"

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -88,9 +88,22 @@ _pleskxml_DBG() {
   fi
 }
 
+# Used by _pleskxml_DBG_VARDUMP to capture all _pleskxml_* variables for debug output
+# Credit to/based on Stephanie Chazelas' snippet:
+# https://unix.stackexchange.com/questions/462280/listing-shell-variables-with-a-fixed-prefix
+_pleskxml_DBG_GET_VAR() {
+  if printf '%s' "$1" | grep -qE '^_pleskxml_'; then
+    __pleskxml_vars="${__pleskxml_vars}$(printf '%s' "$1" | sed 's/^_pleskxml_DBG_GET_VAR //' | sed -E '1 s~^([^=]+)=~    \1 --> ~')${_pleskxml_newline}"
+  fi
+}
+
 # arg1 = severity level (1=least serious, 3=most serious)
 _pleskxml_DBG_VARDUMP() {
-  _pleskxml_DBG "$1" "$(printf '1st lines of current defined variables are now:\n%s\n\n' "$(set | grep '_pleskxml' | sort)")"
+  __pleskxml_vars=''
+  eval "$( set | sed 's/^/_pleskxml_DBG_GET_VAR /' )"
+  _pleskxml_DBG "$1" "$(printf 'Currently defined _pleskxml_* variables are:\n%s\n\n' "$__pleskxml_vars")"
+  #  Old code in case:
+  #  _pleskxml_DBG "$1" "$(printf '1st lines of current defined variables are now:\n%s\n\n' "$(set | grep '_pleskxml' | sort)")"
 }
 
 _pleskxml_DBG_ERR_TRAP() {

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -21,90 +21,90 @@
 # API NOTES:
 
 # 1) The API uses a user/password combination. It should therefore require cURL over HTTPS
-#    with a MAXIMALLY SECURE TLS CIPHER AND GOOD CERT + REVOCATION CHECKS ON THE API URI,
-#    in (almost) all cases.
+#  with a MAXIMALLY SECURE TLS CIPHER AND GOOD CERT + REVOCATION CHECKS ON THE API URI,
+#  in (almost) all cases.
 
-#    Acceptable/valid ciphers and certificate checks can be specified via optional cURL variables (see below).
-#    Note that edge cases may exist where SSL is not yet set up
-#    (e.g. testing Plesk on ones own network), so although highly recommended, this can be OVERRIDDEN.
+#  Acceptable/valid ciphers and certificate checks can be specified via optional cURL variables (see below).
+#  Note that edge cases may exist where SSL is not yet set up
+#  (e.g. testing Plesk on ones own network), so although highly recommended, this can be OVERRIDDEN.
 
 # 2) --anyauth is used with cURL, to ensure the highest available level of encryption.
 
 # 3) The API references domains by a domain ID, when manipulating records. So the code must
-#    initially convert domain names (string) to Plesk domain IDs (numeric).
+#  initially convert domain names (string) to Plesk domain IDs (numeric).
 
 
 # REQUIRED VARIABLES:
 
 # You need to provide the Plesk URI and login (username and password) as follows:
 
-#     export pleskxml_uri="https://www.plesk_uri.org:8443/enterprise/control/agent.php"
-#                         (or something similar)
-#     export pleskxml_user="johndoe"
-#     export pleskxml_pass="XXXXX"
+#   export pleskxml_uri="https://www.plesk_uri.org:8443/enterprise/control/agent.php"
+#             (or something similar)
+#   export pleskxml_user="johndoe"
+#   export pleskxml_pass="XXXXX"
 
 
 # OPTIONAL VARIABLES:
 
 # To use an insecure Plesk URI, set the following:
-#     export pleskxml_allow_insecure_uri=yes
+#   export pleskxml_allow_insecure_uri=yes
 
 # Extra cURL args (for certificate handling, timeout etc):
-#     export pleskxml_optional_curl_args=LIST_OF_ARGS
-#                                        (eg =-v   or ="-H 'HEADER STRINGS'")
+#   export pleskxml_optional_curl_args=LIST_OF_ARGS
+#                    (eg =-v   or ="-H 'HEADER STRINGS'")
 
 # Debug level (0/absent=none, 1=all, 2=major msgs only, 3=minimum msgs/most severe only)
 # If debug level is nonzero, all DBG messages equal to or more severe than this, are displayed.
 # By design if DBG level is 9 for a message, it is ALWAYS shown, this is used for _info and _err
-#     export pleskxml_debug_min_level=2
+#   export pleskxml_debug_min_level=2
 
 
 ############  Before anything else, define dedug functions to be sure they are detected even if while testing #####################
 
 _DBG_EARLY_CHECK_MODE() {
 
-    if printf '%s' "${pleskxml_debug_min_level:-0}" | grep -qE '^[0-3]$' ; then
-        _pleskxml_DBG_LEVEL="${pleskxml_debug_min_level:-0}"
-        _pleskxml_DBG_COUNT=0
-    else
-        _err "Invalid debug level, exiting. \$pleskxml_debug_min_level = '${pleskxml_debug_min_level}' "
-        return 1
-    fi
+  if printf '%s' "${pleskxml_debug_min_level:-0}" | grep -qE '^[0-3]$' ; then
+    _pleskxml_DBG_LEVEL="${pleskxml_debug_min_level:-0}"
+    _pleskxml_DBG_COUNT=0
+  else
+    _err "Invalid debug level, exiting. \$pleskxml_debug_min_level = '${pleskxml_debug_min_level}' "
+    return 1
+  fi
 
-    _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_DBG_LEVEL}' "
-        # This won't display if DBG level was set to zero.
+  _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_DBG_LEVEL}' "
+    # This won't display if DBG level was set to zero.
 }
 
 #  arg1 = severity level (1=least serious, 3=most serious)
 # By design if DBG level is 9 for a MESSAGE, the message is ALWAYS shown, this is used for _info and _err
 #  arg2 = message
 _DBG() {
-    if [ "$1" -eq 9 ] || ( [ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_DBG_LEVEL" ] ); then
-        case $1 in
-            1)    _pleskxml_severity='INFO'
-                ;;
-            2)    _pleskxml_severity='WARN'
-                ;;
-            3)    _pleskxml_severity='ERR'
-                ;;
-            9)    _pleskxml_severity='_ACME.SH'
-                ;;
-        esac
-        _pleskxml_DBG_COUNT=$(( _pleskxml_DBG_COUNT + 1 ))
-        printf '%04d DEBUG [%s]:\n%s\n\n' "$_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$2"
-    fi
+  if [ "$1" -eq 9 ] || ( [ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_DBG_LEVEL" ] ); then
+    case $1 in
+      1)  _pleskxml_severity='INFO'
+        ;;
+      2)  _pleskxml_severity='WARN'
+        ;;
+      3)  _pleskxml_severity='ERR'
+        ;;
+      9)  _pleskxml_severity='_ACME.SH'
+        ;;
+    esac
+    _pleskxml_DBG_COUNT=$(( _pleskxml_DBG_COUNT + 1 ))
+    printf '%04d DEBUG [%s]:\n%s\n\n' "$_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$2"
+  fi
 }
 
 
 #  arg1 = severity level (1=least serious, 3=most serious)
 #  arg2 = message (vardump will be appended)
 _DBG_VARDUMP() {
-    _DBG "$1" "$( printf '%s: 1st lines of current defined variables are now:\n%s\n\n' "${2:-NO_FURTHER_MSG}" "$( set | grep '_pleskxml' | sort )" )"
+  _DBG "$1" "$( printf '%s: 1st lines of current defined variables are now:\n%s\n\n' "${2:-NO_FURTHER_MSG}" "$( set | grep '_pleskxml' | sort )" )"
 }
 
 
 _DBG_ERR_TRAP() {
-    echo "Error on line $1"
+  echo "Error on line $1"
 }
 
 
@@ -135,26 +135,26 @@ _pleskxml_newline='
 #   (otherwise printf repeats the string causing the API call to fail)
 
 _pleskxml_tplt_get_domain_id="<packet><webspace><get><filter><name>%s</name></filter><dataset></dataset></get></webspace></packet>"
-    # Convert domain name to a Plesk internal domain ID
-    # Args:
-    #   the domain name to query
+  # Convert domain name to a Plesk internal domain ID
+  # Args:
+  #   the domain name to query
 
 _pleskxml_tplt_add_txt_record="<packet><dns><add_rec><site-id>%s</site-id><type>TXT</type><host>%s</host><value>%s</value></add_rec></dns></packet>"
-    # Adds a TXT record to a domain
-    # Args:
-    #   the Plesk internal domain ID for the domain
-    #   the "host" entry within the domain, to add this to (eg '_acme_challenge')
-    #   the TXT record value
+  # Adds a TXT record to a domain
+  # Args:
+  #   the Plesk internal domain ID for the domain
+  #   the "host" entry within the domain, to add this to (eg '_acme_challenge')
+  #   the TXT record value
 
 _pleskxml_tplt_rmv_dns_record="<packet><dns><del_rec><filter><id>%s</id></filter></del_rec></dns></packet>"
-    # Adds a TXT record to a domain
-    # Args:
-    #   the Plesk internal ID for the dns record to delete
+  # Adds a TXT record to a domain
+  # Args:
+  #   the Plesk internal ID for the dns record to delete
 
 _pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-id></filter></get_rec></dns></packet>"
-    # Gets all DNS records for a Plesk domain ID
-    # Args:
-    #   the domain id to query
+  # Gets all DNS records for a Plesk domain ID
+  # Args:
+  #   the domain id to query
 
 
 ############  Define public functions #####################
@@ -163,78 +163,78 @@ _pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-
 
 dns_pleskxml_add() {
 
-    _DBG 2 "Entered dns_pleskxml_add($*)..."
+  _DBG 2 "Entered dns_pleskxml_add($*)..."
 
-    _pleskxml_FQDN=$1
-    _pleskxml_TXT_string=$2
+  _pleskxml_FQDN=$1
+  _pleskxml_TXT_string=$2
 
-    # validate variables set by user.
-    # If valid, then matching internal variables will be set with the appropriate checked values
-    # Otherwise exit with an error
+  # validate variables set by user.
+  # If valid, then matching internal variables will be set with the appropriate checked values
+  # Otherwise exit with an error
 
-    _info "Plesk XML: Trying to add a DNS TXT record for acme validation."
-    _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
-    _info "Plesk XML: Checking login and other variables supplied by user"
+  _info "Plesk XML: Trying to add a DNS TXT record for acme validation."
+  _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
+  _info "Plesk XML: Checking login and other variables supplied by user"
 
-    _pleskxml_get_variables
-    _pleskxml_retcode=$?
+  _pleskxml_get_variables
+  _pleskxml_retcode=$?
 
-    _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
+  _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
-        _err "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
+    _err "$_pleskxml_errors"
+    return 1
+  fi
 
-    if [ "$_pleskxml_allow_insecure"  ]; then
-        _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
-    fi
+  if [ "$_pleskxml_allow_insecure"  ]; then
+    _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
+  fi
 
-    # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
+  # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
 
-    _info "Plesk XML: Variables loaded."
-    _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
+  _info "Plesk XML: Variables loaded."
+  _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-    _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
+  _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
-    _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
-    _pleskxml_retcode=$?
+  _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
+  _pleskxml_retcode=$?
 
-    _DBG_VARDUMP 2 'Call has returned'
+  _DBG_VARDUMP 2 'Call has returned'
 
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _err "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _err "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK, valid response containing a valid domain ID must have been found
-    # If not we should have got an error.
+  # OK, valid response containing a valid domain ID must have been found
+  # If not we should have got an error.
 
-    # Try to add the TXT record
+  # Try to add the TXT record
 
-    _DBG 2 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+  _DBG 2 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
-    _info "Plesk XML: Trying to add TXT record to domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'. The TXT string is: '$_pleskxml_TXT_string'."
+  _info "Plesk XML: Trying to add TXT record to domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'. The TXT string is: '$_pleskxml_TXT_string'."
 
-    _pleskxml_add_dns_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
-    _pleskxml_retcode=$?
+  _pleskxml_add_dns_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
+  _pleskxml_retcode=$?
 
-    _DBG_VARDUMP 2 'Call has returned'
+  _DBG_VARDUMP 2 'Call has returned'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _err "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _err "$_pleskxml_errors"
+    return 1
+  fi
 
-    _info 'An ACME Challenge TXT record for '"$_pleskxml_domain"' was added to Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
-    _info "(TO CHECK?: Note that all subdomains under this domain uses the same TXT record.) <-- MAY NOT BE NEEDED"
+  _info 'An ACME Challenge TXT record for '"$_pleskxml_domain"' was added to Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
+  _info "(TO CHECK?: Note that all subdomains under this domain uses the same TXT record.) <-- MAY NOT BE NEEDED"
 
-    _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
+  _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
 
-    return 0
+  return 0
 }
 
 
@@ -244,76 +244,76 @@ dns_pleskxml_add() {
 
 dns_pleskxml_rm() {
 
-    _DBG 2 "Entered dns_pleskxml_rm($*)..."
+  _DBG 2 "Entered dns_pleskxml_rm($*)..."
 
-    _pleskxml_FQDN=$1
-    _pleskxml_TXT_string=$2
+  _pleskxml_FQDN=$1
+  _pleskxml_TXT_string=$2
 
-    # validate variables set by user.
-    # If valid, then matching internal variables will be set with the appropriate checked values
-    # Otherwise exit with an error
+  # validate variables set by user.
+  # If valid, then matching internal variables will be set with the appropriate checked values
+  # Otherwise exit with an error
 
-    _info "Plesk XML: Trying to remove a recently-added DNS TXT record for following acme validation."
-    _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
-    _info "Plesk XML: Checking login and other variables supplied by user"
+  _info "Plesk XML: Trying to remove a recently-added DNS TXT record for following acme validation."
+  _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
+  _info "Plesk XML: Checking login and other variables supplied by user"
 
-    _pleskxml_get_variables
-    _pleskxml_retcode=$?
+  _pleskxml_get_variables
+  _pleskxml_retcode=$?
 
-    _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
+  _DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
-        _err "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
+    _err "$_pleskxml_errors"
+    return 1
+  fi
 
-    if [ "$_pleskxml_allow_insecure" ]; then
-        _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
-    fi
+  if [ "$_pleskxml_allow_insecure" ]; then
+    _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
+  fi
 
-    # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
+  # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
 
-    _info "Plesk XML: Variables loaded."
-    _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
+  _info "Plesk XML: Variables loaded."
+  _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-    _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
+  _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
-    _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
-    _pleskxml_retcode=$?
+  _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
+  _pleskxml_retcode=$?
 
-    _DBG_VARDUMP 2 'Call has returned'
+  _DBG_VARDUMP 2 'Call has returned'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _err "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _err "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK, valid response containing a valid domain ID must have been found
-    # If not we should have got an error.
+  # OK, valid response containing a valid domain ID must have been found
+  # If not we should have got an error.
 
-    # Try to remove the TXT record. First step - get all TXT records
+  # Try to remove the TXT record. First step - get all TXT records
 
-    _info "Plesk XML: Trying to remove TXT record from domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'."
+  _info "Plesk XML: Trying to remove TXT record from domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'."
 
-    _DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+  _DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
-    _pleskxml_rmv_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
-    _pleskxml_retcode=$?
+  _pleskxml_rmv_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
+  _pleskxml_retcode=$?
 
-    _DBG_VARDUMP 2 'Call has returned'
+  _DBG_VARDUMP 2 'Call has returned'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _err "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _err "$_pleskxml_errors"
+    return 1
+  fi
 
-    _info 'A TXT record for '"$_pleskxml_domain"' was removed from Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
+  _info 'A TXT record for '"$_pleskxml_domain"' was removed from Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
 
-    _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
+  _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
 
-    return 0
+  return 0
 }
 
 ####################  Define private functions ##################################
@@ -323,71 +323,71 @@ dns_pleskxml_rm() {
 
 _pleskxml_get_variables() {
 
-    _DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
+  _DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
 
-    _pleskxml_errors=''
+  _pleskxml_errors=''
 
-    # The Plesk XML API needs the base domain (mydomain.com) and host (_acme_challenge) split out from the FQDN
-    # supplied to this module, to manage the relevant DNS records
-    # We assume ACME.SH does most of the validation, but even so, let's check some basic character compliance.
-    # Not checking just [a-z0-9] since the FQDN could be unicode, but this should be reasonably sane.
-    # If not, it'll be over-cautious and block unicode based on bytes, and need fixing.
-    # At most the check can be removed. But it needs to be able to split out a host and a domain.
+  # The Plesk XML API needs the base domain (mydomain.com) and host (_acme_challenge) split out from the FQDN
+  # supplied to this module, to manage the relevant DNS records
+  # We assume ACME.SH does most of the validation, but even so, let's check some basic character compliance.
+  # Not checking just [a-z0-9] since the FQDN could be unicode, but this should be reasonably sane.
+  # If not, it'll be over-cautious and block unicode based on bytes, and need fixing.
+  # At most the check can be removed. But it needs to be able to split out a host and a domain.
 
-    if printf '%s' "$_pleskxml_FQDN" | grep -iEq '^[^][/.:[:space:]^$*'\''"`-][^][/.:[:space:]^$*'\''"`]*(\.[^][/.:[:space:]^$*'\''"`_]+)+$'; then
-        _pleskxml_host="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^([^.]+)\..*$/\1/' )"
-        _pleskxml_domain="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^[^.]+\.(.*)$/\1/' )"
-    else
-        _pleskxml_errors="An invalid domain name (FQDN) was supplied."
-    fi
+  if printf '%s' "$_pleskxml_FQDN" | grep -iEq '^[^][/.:[:space:]^$*'\''"`-][^][/.:[:space:]^$*'\''"`]*(\.[^][/.:[:space:]^$*'\''"`_]+)+$'; then
+    _pleskxml_host="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^([^.]+)\..*$/\1/' )"
+    _pleskxml_domain="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^[^.]+\.(.*)$/\1/' )"
+  else
+    _pleskxml_errors="An invalid domain name (FQDN) was supplied."
+  fi
 
-    # Now process other variables
+  # Now process other variables
 
-    _pleskxml_allow_insecure="${pleskxml_allow_insecure_uri:-no}"
-    if [ "$_pleskxml_allow_insecure" = "yes" ] || [ "$_pleskxml_allow_insecure" = "Yes" ] || [ "$_pleskxml_allow_insecure" = "YES" ]; then
-        # Allow insecure (non-SSL) URI for Plesk. "s" is optional within the "https" URI
-        _pleskxml_allow_insecure=1
-        _pleskxml_uri_prefix_match='https?://'
-    else
-        # Require secure (SSL) URI for Plesk. "s" is mandatory within the "https" URI
-        _pleskxml_allow_insecure=0
-        _pleskxml_uri_prefix_match='https://'
-    fi
+  _pleskxml_allow_insecure="${pleskxml_allow_insecure_uri:-no}"
+  if [ "$_pleskxml_allow_insecure" = "yes" ] || [ "$_pleskxml_allow_insecure" = "Yes" ] || [ "$_pleskxml_allow_insecure" = "YES" ]; then
+    # Allow insecure (non-SSL) URI for Plesk. "s" is optional within the "https" URI
+    _pleskxml_allow_insecure=1
+    _pleskxml_uri_prefix_match='https?://'
+  else
+    # Require secure (SSL) URI for Plesk. "s" is mandatory within the "https" URI
+    _pleskxml_allow_insecure=0
+    _pleskxml_uri_prefix_match='https://'
+  fi
 
 
-    if printf '%s' "${pleskxml_uri:-}" | grep -qiE "^${_pleskxml_uri_prefix_match}"'([a-z0-9][a-z0-9.:-]*|\[[a-f0-9][a-f0-9.:]+\])(:[0-9]{1,5})?(/|$)'; then
-        # URI is "valid enough" to use, and uses https if this is mandatory (= pleskxml_allow_insecure_uri wasn't set)
-        _pleskxml_uri="$pleskxml_uri"
-    else
-        _pleskxml_errors="$_pleskxml_errors"'\nBad or unacceptable URI (If non-SSL HTTP is required, did you set "pleskxml_allow_insecure_uri"?).\nYou should set and export '"$pleskxml_uri"', containing the URI for your Plesk XML API.\nThe URI usually looks like this: https://my_plesk_uri.tld:8443'
-    fi
+  if printf '%s' "${pleskxml_uri:-}" | grep -qiE "^${_pleskxml_uri_prefix_match}"'([a-z0-9][a-z0-9.:-]*|\[[a-f0-9][a-f0-9.:]+\])(:[0-9]{1,5})?(/|$)'; then
+    # URI is "valid enough" to use, and uses https if this is mandatory (= pleskxml_allow_insecure_uri wasn't set)
+    _pleskxml_uri="$pleskxml_uri"
+  else
+    _pleskxml_errors="$_pleskxml_errors"'\nBad or unacceptable URI (If non-SSL HTTP is required, did you set "pleskxml_allow_insecure_uri"?).\nYou should set and export '"$pleskxml_uri"', containing the URI for your Plesk XML API.\nThe URI usually looks like this: https://my_plesk_uri.tld:8443'
+  fi
 
-    if printf '%s' "${pleskxml_user:-}" | grep -qiE '^[a-z0-9@%._-]+$'; then
-        # USER is "valid enough" to use - Plesk doesn't stipulate valid chars, but thewse are probably "safe enough". We will find out if they aren't, the hard way :)
-        # Note, we cannot assume "safe" characters when we use this value!
-        _pleskxml_user="$pleskxml_user"
-    else
-        _pleskxml_errors="$_pleskxml_errors"'\nBad or unacceptable USER ACCOUNT for Plesk authentication. You should set and export '"$pleskxml_user."
-    fi
+  if printf '%s' "${pleskxml_user:-}" | grep -qiE '^[a-z0-9@%._-]+$'; then
+    # USER is "valid enough" to use - Plesk doesn't stipulate valid chars, but thewse are probably "safe enough". We will find out if they aren't, the hard way :)
+    # Note, we cannot assume "safe" characters when we use this value!
+    _pleskxml_user="$pleskxml_user"
+  else
+    _pleskxml_errors="$_pleskxml_errors"'\nBad or unacceptable USER ACCOUNT for Plesk authentication. You should set and export '"$pleskxml_user."
+  fi
 
-    if [ "${pleskxml_pass:-}" != "" ]; then
-        # PASS is "valid enough" to use - Plesk doesn't stipulate valid chars, but thewse are probably "safe enough". We will find out if they aren't, the hard way :)
-        # Note, we cannot assume "safe" characters when we use this value!
-        _pleskxml_pass="$pleskxml_pass"
-    else
-        _pleskxml_errors="$_pleskxml_errors"'\nEmpty USER PASSWORD for Plesk authentication. You should set and export '"$pleskxml_pass."
-    fi
+  if [ "${pleskxml_pass:-}" != "" ]; then
+    # PASS is "valid enough" to use - Plesk doesn't stipulate valid chars, but thewse are probably "safe enough". We will find out if they aren't, the hard way :)
+    # Note, we cannot assume "safe" characters when we use this value!
+    _pleskxml_pass="$pleskxml_pass"
+  else
+    _pleskxml_errors="$_pleskxml_errors"'\nEmpty USER PASSWORD for Plesk authentication. You should set and export '"$pleskxml_pass."
+  fi
 
-    # Ensure if not supplied, optional curl args are an empty string
-    _pleskxml_optional_curl_args="${pleskxml_optional_curl_args:-}"
+  # Ensure if not supplied, optional curl args are an empty string
+  _pleskxml_optional_curl_args="${pleskxml_optional_curl_args:-}"
 
-    if [ -n "$_pleskxml_errors" ]; then
-        _DBG_VARDUMP 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
-        return 1
-    else
-        _DBG_VARDUMP 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
-        return 0
-    fi
+  if [ -n "$_pleskxml_errors" ]; then
+    _DBG_VARDUMP 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
+    return 1
+  else
+    _DBG_VARDUMP 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
+    return 0
+  fi
 }
 
 
@@ -399,215 +399,215 @@ _pleskxml_get_variables() {
 _pleskxml_api_request() {
 
 
-    _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
+  _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
 
-    _pleskxml_errors=''
-    _pleskxml_result=''
-    _pleskxml_prettyprint_result=''
-    _pleskxml_result=''
+  _pleskxml_errors=''
+  _pleskxml_result=''
+  _pleskxml_prettyprint_result=''
+  _pleskxml_result=''
 
-    # Of all the API commands we use, just one of them can return multiple results sections
-    # so the validation process after cURL returns, will differ for that case.....
+  # Of all the API commands we use, just one of them can return multiple results sections
+  # so the validation process after cURL returns, will differ for that case.....
 
-    if [ "$1" = "$_pleskxml_tplt_get_dns_records" ]; then
-        _pleskxml_multiple_results_allowed=1
-    else
-        _pleskxml_multiple_results_allowed=0
-    fi
+  if [ "$1" = "$_pleskxml_tplt_get_dns_records" ]; then
+    _pleskxml_multiple_results_allowed=1
+  else
+    _pleskxml_multiple_results_allowed=0
+  fi
 
-    # Sanitise user+pw for single quote enclosure, ands build Plesk arg string
+  # Sanitise user+pw for single quote enclosure, ands build Plesk arg string
 
-    _pleskxml_user="$( printf '%s' "$_pleskxml_user" | sed "s/'/'\\''/g" )"
-    _pleskxml_pass="$( printf '%s' "$_pleskxml_pass" | sed "s/'/'\\''/g" )"
-    _pleskxml_APICMD="$( printf "$1 %0.0s%0.0s%0.0s" "$2" "$3" "$4" )"
-        # Add some %0.0s at the end of the format string in the 1st arg, to cope with ("absorb") variable number of further args
-        # otherwise this will repeat the format string which we don't want.
-        # If there weren't additional args, these will evaluate to empty strings/blank, and be harmless.
+  _pleskxml_user="$( printf '%s' "$_pleskxml_user" | sed "s/'/'\\''/g" )"
+  _pleskxml_pass="$( printf '%s' "$_pleskxml_pass" | sed "s/'/'\\''/g" )"
+  _pleskxml_APICMD="$( printf "$1 %0.0s%0.0s%0.0s" "$2" "$3" "$4" )"
+    # Add some %0.0s at the end of the format string in the 1st arg, to cope with ("absorb") variable number of further args
+    # otherwise this will repeat the format string which we don't want.
+    # If there weren't additional args, these will evaluate to empty strings/blank, and be harmless.
 
-    _pleskxml_curlargs="--anyauth \
-               -X POST \
-               -H 'Content-Type: text/xml' \
-               -H 'HTTP_PRETTY_PRINT: TRUE' \
-               -H 'HTTP_AUTH_LOGIN: ${_pleskxml_user}' \
-               -H 'HTTP_AUTH_PASSWD: ${_pleskxml_pass}' \
-               -d '${_pleskxml_APICMD}' \
-               ${_pleskxml_optional_curl_args}"
+  _pleskxml_curlargs="--anyauth \
+         -X POST \
+         -H 'Content-Type: text/xml' \
+         -H 'HTTP_PRETTY_PRINT: TRUE' \
+         -H 'HTTP_AUTH_LOGIN: ${_pleskxml_user}' \
+         -H 'HTTP_AUTH_PASSWD: ${_pleskxml_pass}' \
+         -d '${_pleskxml_APICMD}' \
+         ${_pleskxml_optional_curl_args}"
 
-    _DBG_VARDUMP 2 'About to call Plesk via cURL'
+  _DBG_VARDUMP 2 'About to call Plesk via cURL'
 
-    _DBG 2 "$( printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" )"
-        _pleskxml_prettyprint_result="$( eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null )"
-        _pleskxml_retcode="$?"
-    _DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
-    _DBG 2 "retcode = $_pleskxml_retcode"
+  _DBG 2 "$( printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" )"
+    _pleskxml_prettyprint_result="$( eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null )"
+    _pleskxml_retcode="$?"
+  _DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
+  _DBG 2 "retcode = $_pleskxml_retcode"
 
  # BUGFIX TO CHECK - WILL RETCODE FROM cURL BE AVAILABLE HERE?
 
-    # Abort if cURL failed
+  # Abort if cURL failed
 
-    if [ $_pleskxml_retcode -ne 0 ]; then
-        _pleskxml_errors="Exiting due to cURL error when querying Plesk XML API. The cURL return code was: $_pleskxml_retcode."
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ]; then
+    _pleskxml_errors="Exiting due to cURL error when querying Plesk XML API. The cURL return code was: $_pleskxml_retcode."
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK. Next, check XML reply was OK. Start by pushing it into one line, with leading/trailing space trimmed.
+  # OK. Next, check XML reply was OK. Start by pushing it into one line, with leading/trailing space trimmed.
 
-#    _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
-#            awk '{$1=$1};1' | \
-#            tr -d '\n' \
-#            )"
+#  _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
+#      awk '{$1=$1};1' | \
+#      tr -d '\n' \
+#      )"
 
-    _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
-            sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
-            tr -d '\n' \
-            )"
-    
-    _DBG_VARDUMP 2 'cURL succeeded, valid cURL response obtained'
+  _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
+      sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
+      tr -d '\n' \
+      )"
+  
+  _DBG_VARDUMP 2 'cURL succeeded, valid cURL response obtained'
 
-    # Now we need to check item by item if it's OK.
-    # As we go, we will strip out "known OK" stuff to leave the core reply.
+  # Now we need to check item by item if it's OK.
+  # As we go, we will strip out "known OK" stuff to leave the core reply.
 
-    # XML header and packet version?
+  # XML header and packet version?
 
-    _DBG 2 'Checking <?xml> and <packet> tags exist...'
+  _DBG 2 'Checking <?xml> and <packet> tags exist...'
 
-    if printf '%s' "$_pleskxml_result" | grep -qiEv '^<\?xml version=[^>]+><packet version=[^>]+>.*</packet>$'; then
-        # Error - should have <?xml><packet>...</packet>. Abort
-        _pleskxml_errors="Error when querying Plesk XML API. The API did not return a valid XML response. The response was:${_pleskxml_newline}${_pleskxml_prettyprint_result}${_pleskxml_newline}The collapsed version was:${_pleskxml_newline}'${_pleskxml_result}'${_pleskxml_newline}"
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    else
-        # So far so good. Strip the <?xml> and <packet>...</packet> tags and continue
-        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-                sed -E 's/^<\?xml version[^>]+><packet version[^>]+>(.*)<\/packet>$/\1/' \
-                )"
-    fi
-
-    _DBG 2 "Checking <system> tags don't exist..."
-
-    # <system> section found anywhere in response?
-    # This usually means some kind of basic API error such as login failure, bad XML request, etc
-
-
-    if printf '%s' "$_pleskxml_result" | grep -qiE '<system>.*</system>'; then
-        # Error - shouldn't contain <system>...</system>. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The result contained a <system> tag.\nThis usually indicates an invalid login, badly formatted API request or other error. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
-
-
-    _DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
-
-
-    # Check results section. Most commands only have one results section.
-    # But some (i.e., get all DNS records for a domain) have many results sections,
-    # and we will need to check each <results>...</results> section separately.
-    # So this gets a bit messy, especially as we don't have non-greedy regex
-    # and we will have to work around that as well.
-
-    # For this, we will split the string up again with exactly 1 <result> section per line.
-    # We check there is at least one result section. Then we add newlines before and after
-    # any <result>...</result> and ignore any lines that don't contain '<result>'.
-
-    if printf '%s' "$_pleskxml_result" | grep -qiEv '<result>.*</result>'; then
-        # Error - doesn't contain <result>...</result>. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The result did not contain a <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
-
-    _DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
-
+  if printf '%s' "$_pleskxml_result" | grep -qiEv '^<\?xml version=[^>]+><packet version=[^>]+>.*</packet>$'; then
+    # Error - should have <?xml><packet>...</packet>. Abort
+    _pleskxml_errors="Error when querying Plesk XML API. The API did not return a valid XML response. The response was:${_pleskxml_newline}${_pleskxml_prettyprint_result}${_pleskxml_newline}The collapsed version was:${_pleskxml_newline}'${_pleskxml_result}'${_pleskxml_newline}"
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  else
+    # So far so good. Strip the <?xml> and <packet>...</packet> tags and continue
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-        sed "s/<result>/\\${_pleskxml_newline}<result>/g" | \
-        sed "s/<\/result>/<\/result>\\${_pleskxml_newline}/g" | \
-        grep '<result>' \
-         )"
+        sed -E 's/^<\?xml version[^>]+><packet version[^>]+>(.*)<\/packet>$/\1/' \
+        )"
+  fi
 
-    # Detect and abort if there are >1 <result> sections and we're ponly expecting 1 section.
+  _DBG 2 "Checking <system> tags don't exist..."
 
-    _pleskxml_linecount=$( printf '%s\n' "$_pleskxml_result" | wc -l )
+  # <system> section found anywhere in response?
+  # This usually means some kind of basic API error such as login failure, bad XML request, etc
 
-    _DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
 
-    _DBG_VARDUMP 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
+  if printf '%s' "$_pleskxml_result" | grep -qiE '<system>.*</system>'; then
+    # Error - shouldn't contain <system>...</system>. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The result contained a <system> tag.\nThis usually indicates an invalid login, badly formatted API request or other error. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    if [ $_pleskxml_multiple_results_allowed -eq 0 ] && [ "$_pleskxml_linecount" -gt 1 ]; then
-        # Error - contains multiple <result> sections. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The result contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
 
-    _DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
+  _DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
 
-    # Loop through each <result> section, checking every line has exactly one result section,
-    # containing exactly one status section, which contains <status>ok</status>
 
-    while IFS= read -r _pleskxml_line; do
+  # Check results section. Most commands only have one results section.
+  # But some (i.e., get all DNS records for a domain) have many results sections,
+  # and we will need to check each <results>...</results> section separately.
+  # So this gets a bit messy, especially as we don't have non-greedy regex
+  # and we will have to work around that as well.
 
-        # _pleskxml_line *should* contain a single result section.
-        # Check this is correct.
+  # For this, we will split the string up again with exactly 1 <result> section per line.
+  # We check there is at least one result section. Then we add newlines before and after
+  # any <result>...</result> and ignore any lines that don't contain '<result>'.
+
+  if printf '%s' "$_pleskxml_result" | grep -qiEv '<result>.*</result>'; then
+    # Error - doesn't contain <result>...</result>. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The result did not contain a <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
+
+  _DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
+
+  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+    sed "s/<result>/\\${_pleskxml_newline}<result>/g" | \
+    sed "s/<\/result>/<\/result>\\${_pleskxml_newline}/g" | \
+    grep '<result>' \
+     )"
+
+  # Detect and abort if there are >1 <result> sections and we're ponly expecting 1 section.
+
+  _pleskxml_linecount=$( printf '%s\n' "$_pleskxml_result" | wc -l )
+
+  _DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
+
+  _DBG_VARDUMP 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
+
+  if [ $_pleskxml_multiple_results_allowed -eq 0 ] && [ "$_pleskxml_linecount" -gt 1 ]; then
+    # Error - contains multiple <result> sections. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The result contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
+
+  _DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
+
+  # Loop through each <result> section, checking every line has exactly one result section,
+  # containing exactly one status section, which contains <status>ok</status>
+
+  while IFS= read -r _pleskxml_line; do
+
+    # _pleskxml_line *should* contain a single result section.
+    # Check this is correct.
 
 
 # _DBG "Checking a <result> section... content is ${_pleskxml_line}"
 
-        if printf '%s' "$_pleskxml_line" | grep -qiEv '^<result>.*</result>$'; then
-            # Error - doesn't contain <result>...</result>. Abort
-            _pleskxml_errors='Error when querying Plesk XML API. A <result> section was not found where expected.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-            return 1
-        fi
+    if printf '%s' "$_pleskxml_line" | grep -qiEv '^<result>.*</result>$'; then
+      # Error - doesn't contain <result>...</result>. Abort
+      _pleskxml_errors='Error when querying Plesk XML API. A <result> section was not found where expected.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+      return 1
+    fi
 
-        # Now strip the <results> tag and check there is precisely one <status> section and its ciontents are "ok"
+    # Now strip the <results> tag and check there is precisely one <status> section and its ciontents are "ok"
 
-        _pleskxml_line="$( printf '%s' "$_pleskxml_line" | sed -E 's/^<result>(.*)<\/result>$/\1/' )"
+    _pleskxml_line="$( printf '%s' "$_pleskxml_line" | sed -E 's/^<result>(.*)<\/result>$/\1/' )"
 
-        if printf '%s' "$_pleskxml_line" | grep -qiEv '<status>.*</status>'; then
-            # Error - doesn't contain <status>...</status>. Abort
-            _pleskxml_errors='Error when querying Plesk XML API. A <result> section did not contain a <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-            _DBG 2 "$_pleskxml_errors"
-            return 1
-        elif printf '%s' "$_pleskxml_line" | grep -qiE '<status>.*</status>.*<status>'; then
-            # Error - contains <status>...</status>...<status>. Abort
-            _pleskxml_errors='Error when querying Plesk XML API. A <result> section contained more than one <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-            _DBG 2 "$_pleskxml_errors"
-            return 1
-        elif printf '%s' "$_pleskxml_line" | grep -qiEv '<status>ok</status>'; then
-            # Error - doesn't contain <status>ok</status>. Abort
-            _pleskxml_errors='Error when querying Plesk XML API. A <status> tag did not contain "<status>ok</status>". The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-            _DBG 2 "$_pleskxml_errors"
-            return 1
-        fi
+    if printf '%s' "$_pleskxml_line" | grep -qiEv '<status>.*</status>'; then
+      # Error - doesn't contain <status>...</status>. Abort
+      _pleskxml_errors='Error when querying Plesk XML API. A <result> section did not contain a <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+      _DBG 2 "$_pleskxml_errors"
+      return 1
+    elif printf '%s' "$_pleskxml_line" | grep -qiE '<status>.*</status>.*<status>'; then
+      # Error - contains <status>...</status>...<status>. Abort
+      _pleskxml_errors='Error when querying Plesk XML API. A <result> section contained more than one <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+      _DBG 2 "$_pleskxml_errors"
+      return 1
+    elif printf '%s' "$_pleskxml_line" | grep -qiEv '<status>ok</status>'; then
+      # Error - doesn't contain <status>ok</status>. Abort
+      _pleskxml_errors='Error when querying Plesk XML API. A <status> tag did not contain "<status>ok</status>". The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+      _DBG 2 "$_pleskxml_errors"
+      return 1
+    fi
 
 # _DBG "Line is OK. Looping to next line or exiting..."
 
-    done << EOL
+  done << EOL
 $_pleskxml_result
 EOL
 
-    # So far so good. Remove all <status>ok</status> sections as they're checked now.
+  # So far so good. Remove all <status>ok</status> sections as they're checked now.
 
-    _DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
+  _DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
 
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-            sed -E 's/<status>ok<\/status>//g' \
-            )"
+  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+      sed -E 's/<status>ok<\/status>//g' \
+      )"
 
-    # Result is OK. Remove any redundant self-closing tags, and <data> or </data> tags, and exit
+  # Result is OK. Remove any redundant self-closing tags, and <data> or </data> tags, and exit
 
-    _DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
+  _DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
 
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-            sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g' \
-            )"
+  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+      sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g' \
+      )"
 
-    _DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
+  _DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
 
-    _DBG_VARDUMP 2 'Successfully exiting Plesk XML API function'
+  _DBG_VARDUMP 2 'Successfully exiting Plesk XML API function'
 
-    return 0
+  return 0
 
 }
 
@@ -616,88 +616,88 @@ EOL
 
 _pleskxml_get_domain_ID() {
 
-    _DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
+  _DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
 
-    # Call cURL to convert a domain name to a plesk domain ID.
+  # Call cURL to convert a domain name to a plesk domain ID.
 
-    _DBG 2 'About to make API request (domain name -> domain ID)'
+  _DBG 2 'About to make API request (domain name -> domain ID)'
 
-    _pleskxml_api_request "$_pleskxml_tplt_get_domain_id" "$1"
-    _pleskxml_retcode=$?
-        # $1 is the domain name we wish to convert to a Plesk domain ID
+  _pleskxml_api_request "$_pleskxml_tplt_get_domain_id" "$1"
+  _pleskxml_retcode=$?
+    # $1 is the domain name we wish to convert to a Plesk domain ID
 
-    _DBG 2 'Returned from API request, now back in get_domain_ID()'
+  _DBG 2 'Returned from API request, now back in get_domain_ID()'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK, we should have a domain ID. Let's check and return it if so.
+  # OK, we should have a domain ID. Let's check and return it if so.
 
-    # Result should comprise precisely one <result> section
+  # Result should comprise precisely one <result> section
 
-    _DBG 2 'Testing API return data for one <result> and removing if so'
+  _DBG 2 'Testing API return data for one <result> and removing if so'
 
-    if printf '%s' "$_pleskxml_result" | grep -qiEv '^<result>.*</result>$'; then
-        # Error - doesn't comprise <result>DOMAINNAME</result>. Something's wrong. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The API did not comprise a <result> section containing all other data.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    elif printf '%s' "$_pleskxml_result" | grep -qiE '<result>.*<result>'; then
-        # Error - contains <result>...</result>...<result>. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    else
-        # So far so good. Remove the <result>...</result> section and continue
-        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-                sed -E 's/(^<result>|<\/result>$)//g' \
-                )"
-    fi
-
-    # Result should contain precisely one <filter-id> section, containing the domain name inquired.
-
-    _DBG 2 'Testing API return data for one <filter-id> and removing if so'
-
-    if printf '%s' "$_pleskxml_result" | grep -qiv "<filter-id>$1</filter-id>"; then
-        # Error - doesn't contain <filter-id>DOMAINNAME</filter-id>. Something's wrong. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <filter-id> section containing the domain name.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    elif printf '%s' "$_pleskxml_result" | grep -qiE '<filter-id>.*<filter-id>'; then
-        # Error - contains <filter-id>...</filter-id>...<filter-id>. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <filter-id> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    else
-        # So far so good. Remove the <filter-id>...</filter-id> section and continue
-        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-                sed "s/<filter-id>$1<\/filter-id>//" \
-                )"
-    fi
-
-    # All that should be left is one section, containing <id>DOMAIN_ID</id>
-
-    _DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
-
-    if printf '%s' "$_pleskxml_result" | grep -qiEv '^<id>[0-9]+</id>$'; then
-        # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <id>[NUMERIC_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
-
-    # SUCCESS! Remove the surrounding <id> tag and return the value!
-
+  if printf '%s' "$_pleskxml_result" | grep -qiEv '^<result>.*</result>$'; then
+    # Error - doesn't comprise <result>DOMAINNAME</result>. Something's wrong. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The API did not comprise a <result> section containing all other data.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  elif printf '%s' "$_pleskxml_result" | grep -qiE '<result>.*<result>'; then
+    # Error - contains <result>...</result>...<result>. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  else
+    # So far so good. Remove the <result>...</result> section and continue
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-            sed -E 's/^<id>([0-9]+)<\/id>$/\1/' \
-            )"
+        sed -E 's/(^<result>|<\/result>$)//g' \
+        )"
+  fi
 
-    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
+  # Result should contain precisely one <filter-id> section, containing the domain name inquired.
 
-    return 0
+  _DBG 2 'Testing API return data for one <filter-id> and removing if so'
+
+  if printf '%s' "$_pleskxml_result" | grep -qiv "<filter-id>$1</filter-id>"; then
+    # Error - doesn't contain <filter-id>DOMAINNAME</filter-id>. Something's wrong. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <filter-id> section containing the domain name.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  elif printf '%s' "$_pleskxml_result" | grep -qiE '<filter-id>.*<filter-id>'; then
+    # Error - contains <filter-id>...</filter-id>...<filter-id>. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <filter-id> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  else
+    # So far so good. Remove the <filter-id>...</filter-id> section and continue
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+        sed "s/<filter-id>$1<\/filter-id>//" \
+        )"
+  fi
+
+  # All that should be left is one section, containing <id>DOMAIN_ID</id>
+
+  _DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
+
+  if printf '%s' "$_pleskxml_result" | grep -qiEv '^<id>[0-9]+</id>$'; then
+    # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <id>[NUMERIC_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
+
+  # SUCCESS! Remove the surrounding <id> tag and return the value!
+
+  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+      sed -E 's/^<id>([0-9]+)<\/id>$/\1/' \
+      )"
+
+  _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
+
+  return 0
 
 }
 
@@ -708,112 +708,112 @@ _pleskxml_get_domain_ID() {
 
 _pleskxml_get_dns_records() {
 
-    _DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
+  _DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
 
-    # First, we need to get all DNS records, and check the list is valid
+  # First, we need to get all DNS records, and check the list is valid
 
-    _DBG 2 'About to make API request (get DNS records)'
+  _DBG 2 'About to make API request (get DNS records)'
 
-    _pleskxml_api_request "$_pleskxml_tplt_get_dns_records" "$1"
-    _pleskxml_retcode=$?
-        # $1 is the Plesk internal domain ID for the domain
+  _pleskxml_api_request "$_pleskxml_tplt_get_dns_records" "$1"
+  _pleskxml_retcode=$?
+    # $1 is the Plesk internal domain ID for the domain
 
-    _DBG 2 'Returned from API request, now back in get_txt_records()'
+  _DBG 2 'Returned from API request, now back in get_txt_records()'
 
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK, we should have a <result> section containing a list of DNS records.
-    # Now keep only the TXT records
+  # OK, we should have a <result> section containing a list of DNS records.
+  # Now keep only the TXT records
 
-    _DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+  _DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
 
-    if [ -n "${2:-}" ]; then
-        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-                grep "<type>$2</type>" \
-                )"
-        _DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
-    else
-        _DBG 2 'Not filtering DNS records. All records will be returned.'
-    fi
+  if [ -n "${2:-}" ]; then
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+        grep "<type>$2</type>" \
+        )"
+    _DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+  else
+    _DBG 2 'Not filtering DNS records. All records will be returned.'
+  fi
 
-    _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
-    return 0
+  _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
+  return 0
 }
 
 
 
 _pleskxml_add_txt_record() {
 
-    _DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
+  _DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
 
-    _DBG 2 'About to make API request (add TXT record)'
+  _DBG 2 'About to make API request (add TXT record)'
 
-    _pleskxml_api_request "$_pleskxml_tplt_add_txt_record" "$1" "$2" "$3"
-    _pleskxml_retcode=$?
+  _pleskxml_api_request "$_pleskxml_tplt_add_txt_record" "$1" "$2" "$3"
+  _pleskxml_retcode=$?
 
-        # $1 is the Plesk internal domain ID for the domain
-        # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
-        # $3 is the TXT record value
+    # $1 is the Plesk internal domain ID for the domain
+    # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
+    # $3 is the TXT record value
 
-    _DBG 2 'Returned from API request, now back in add_txt_record()'
+  _DBG 2 'Returned from API request, now back in add_txt_record()'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK, we should have added a TXT record. Let's check and return success if so.
-    # All that should be left in the result, is one section, containing <result><id>PLESK_NEW_DNS_RECORD_ID</id></result>
+  # OK, we should have added a TXT record. Let's check and return success if so.
+  # All that should be left in the result, is one section, containing <result><id>PLESK_NEW_DNS_RECORD_ID</id></result>
 
-    if printf '%s' "$_pleskxml_result" | grep -qivE '^<result><id>[0-9]+</id></result>$'; then
-        # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
-        _pleskxml_errors='Error when calling Plesk XML API. The API did not contain the expected <id>[PLESK_NEW_DNS_RECORD_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  if printf '%s' "$_pleskxml_result" | grep -qivE '^<result><id>[0-9]+</id></result>$'; then
+    # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
+    _pleskxml_errors='Error when calling Plesk XML API. The API did not contain the expected <id>[PLESK_NEW_DNS_RECORD_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    # SUCCESS! Remove the surrounding <result><id> tags and return the value!
-    # (although we don't actually use it!
+  # SUCCESS! Remove the surrounding <result><id> tags and return the value!
+  # (although we don't actually use it!
 
-    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-            sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/" \
-            )"
+  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+      sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/" \
+      )"
 
-    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
+  _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
 
-    return 0
+  return 0
 }
 
 _pleskxml_rmv_dns_record() {
 
-    _DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
+  _DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
 
-    _DBG 2 'About to make API request (rmv TXT record)'
+  _DBG 2 'About to make API request (rmv TXT record)'
 
-    _pleskxml_api_request "$_pleskxml_tplt_rmv_dns_record" "$1"
-    _pleskxml_retcode=$?
+  _pleskxml_api_request "$_pleskxml_tplt_rmv_dns_record" "$1"
+  _pleskxml_retcode=$?
 
-        # $1 is the Plesk internal domain ID for the TXT record
+    # $1 is the Plesk internal domain ID for the TXT record
 
-    _DBG 2 'Returned from API request, now back in rmv_dns_record()'
+  _DBG 2 'Returned from API request, now back in rmv_dns_record()'
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK, we should have removed a TXT record. If it failed, there wouldn't have been a "status:ok" above
+  # OK, we should have removed a TXT record. If it failed, there wouldn't have been a "status:ok" above
 
-    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
+  _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
 
-    return 0
+  return 0
 }
 
 
@@ -823,76 +823,76 @@ _pleskxml_rmv_dns_record() {
 _pleskxml_rmv_txt_record() {
 
 
-    _DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
+  _DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
 
-    _pleskxml_get_dns_records "$1" 'TXT'
-    _pleskxml_retcode=$?
-        # $1 is the Plesk internal domain ID for the domain
+  _pleskxml_get_dns_records "$1" 'TXT'
+  _pleskxml_retcode=$?
+    # $1 is the Plesk internal domain ID for the domain
 
-    _DBG 2 'Returned from API request, now back in rmv_txt_record()'
+  _DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
 
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-    # OK, we should have a <result> section containing a list of DNS TXT records.
-    # Now we need to find our desired record in it (if it exists).
-    # and might as well collapse any successful matches to a signle line for line-count purposes at the same time
+  # OK, we should have a <result> section containing a list of DNS TXT records.
+  # Now we need to find our desired record in it (if it exists).
+  # and might as well collapse any successful matches to a signle line for line-count purposes at the same time
 
-    _DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
+  _DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
+
+  _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+      grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." | \
+      grep -F "<value>${3:-<NON_MATCHING_GARBAGE>}</value>" | \
+      sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
+      tr -d '\n' \
+      )"
+    # Run 2 separate GREP filters, because the host and value order isn't mandatory in the API return data
+    # ands this avoids regex and escaping which is easier
+    # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
+
+  _DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
+
+  if printf '%s' "$_pleskxml_result" | grep -qiE "<result>.*<result>"; then
+    # Error - contains <result>...</result>...<result>. Abort
+    _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
+
+  if printf '%s\n' "$_pleskxml_result" | grep -qiv "<result>"; then
+    # No matching TXT records, so we're done.
+    _info "Couldn't find a TXT record matching the requested host/value. Not an error, but a concern..."
+    _DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
+    _pleskxml_result=''
+    return 0
+  fi
+
+  # If we get here, there was a single TXT record match, so we delete it.
 
     _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-            grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." | \
-            grep -F "<value>${3:-<NON_MATCHING_GARBAGE>}</value>" | \
-            sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
-            tr -d '\n' \
-            )"
-        # Run 2 separate GREP filters, because the host and value order isn't mandatory in the API return data
-        # ands this avoids regex and escaping which is easier
-        # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
+        sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/' \
+        )"
 
-    _DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
+  _DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
 
-    if printf '%s' "$_pleskxml_result" | grep -qiE "<result>.*<result>"; then
-        # Error - contains <result>...</result>...<result>. Abort
-        _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
+  _pleskxml_rmv_dns_record "$_pleskxml_result"
+  _pleskxml_retcode=$?
 
-    if printf '%s\n' "$_pleskxml_result" | grep -qiv "<result>"; then
-        # No matching TXT records, so we're done.
-        _info "Couldn't find a TXT record matching the requested host/value. Not an error, but a concern..."
-        _DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
-        _pleskxml_result=''
-        return 0
-    fi
+  _DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
-    # If we get here, there was a single TXT record match, so we delete it.
+  if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+    # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+    _DBG 2 "$_pleskxml_errors"
+    return 1
+  fi
 
-        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
-                sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/' \
-                )"
+  _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
 
-    _DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
-
-    _pleskxml_rmv_dns_record "$_pleskxml_result"
-    _pleskxml_retcode=$?
-
-    _DBG 2 'Returned from API request, now back in rmv_txt_record()'
-
-    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
-        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
-        _DBG 2 "$_pleskxml_errors"
-        return 1
-    fi
-
-    _DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
-
-    return 0
+  return 0
 }
 
 
@@ -902,14 +902,14 @@ exit
 
 
 # defined by user
-    pleskxml_uri="https://plesk.XXXXX.net:8443/enterprise/control/agent.php"
-    pleskxml_user="XXXXX"
-    pleskxml_pass="XXXXX"
-    pleskxml_debug_min_level=3
+  pleskxml_uri="https://plesk.XXXXX.net:8443/enterprise/control/agent.php"
+  pleskxml_user="XXXXX"
+  pleskxml_pass="XXXXX"
+  pleskxml_debug_min_level=3
 
 # defined from args by module
-    _pleskxml_FQDN="_acme_challenge.XXXXX.com"
-    _pleskxml_TXT_string='~test~string~'
+  _pleskxml_FQDN="_acme_challenge.XXXXX.com"
+  _pleskxml_TXT_string='~test~string~'
 
 printf '\n\n\n\n======================================================================== START OF RUN\n\n'
 

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -94,6 +94,7 @@ _pleskxml_DBG() {
 _pleskxml_DBG_GET_VAR() {
   case "$1" in _pleskxml_*)
     __pleskxml_vars="${__pleskxml_vars}$(printf '%s' "$1" | sed 's/^_pleskxml_DBG_GET_VAR //' | sed -E '1 s~^([^=]+)=~    \1 --> "~')\"${_pleskxml_newline}"
+    ;;
   esac
   # Old code in case:
   #   if printf '%s' "$1" | grep -qE '^_pleskxml_'; then

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -106,15 +106,12 @@ _DBG_ERR_TRAP() {
 
 _DBG_EARLY_CHECK_MODE
 
-
 ############  Set up static/private variables #####################
-
 
 _pleskxml_curlpath=/usr/local/bin/curl
 
 _pleskxml_newline='
 '
-
 
 # Plesk XML templates.
 #   Note ALL TEMPLATES MUST HAVE EXACTLY 3 %s PLACEHOLDERS
@@ -141,7 +138,6 @@ _pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-
 #   Gets all DNS records for a Plesk domain ID
 #   Args:
 #     the domain id to query
-
 
 ############  Define public functions #####################
 

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -92,9 +92,13 @@ _pleskxml_DBG() {
 # Credit to/based on Stephanie Chazelas' snippet:
 # https://unix.stackexchange.com/questions/462280/listing-shell-variables-with-a-fixed-prefix
 _pleskxml_DBG_GET_VAR() {
-  if printf '%s' "$1" | grep -qE '^_pleskxml_'; then
-    __pleskxml_vars="${__pleskxml_vars}$(printf '%s' "$1" | sed 's/^_pleskxml_DBG_GET_VAR //' | sed -E '1 s~^([^=]+)=~    \1 --> ~')${_pleskxml_newline}"
-  fi
+  case "$1" in (_pleskxml_*)
+    __pleskxml_vars="${__pleskxml_vars}$(printf '%s' "$1" | sed 's/^_pleskxml_DBG_GET_VAR //' | sed -E '1 s~^([^=]+)=~    \1 --> "~')\"${_pleskxml_newline}"
+  esac
+  # Old code in case:
+  #   if printf '%s' "$1" | grep -qE '^_pleskxml_'; then
+  #     __pleskxml_vars="${__pleskxml_vars}$(printf '%s' "$1" | sed 's/^_pleskxml_DBG_GET_VAR //' | sed -E '1 s~^([^=]+)=~    \1 --> ~')${_pleskxml_newline}"
+  #   fi
 }
 
 # arg1 = severity level (1=least serious, 3=most serious)

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -1,0 +1,992 @@
+#!/usr/bin/env sh
+
+# Name: dns_pleskxml.sh
+# Created by Stilez.
+# Uses Plesk XML API to add/remove text records
+# Repository: https://github.com/Neilpang/acme.sh
+
+# v0.1 alpha - 2018-08-13
+
+# This DNS01 method allows acme.sh to set DNS TXT records 
+# using the Plesk XML API described at:
+#   https://docs.plesk.com/en-US/12.5/api-rpc/about-xml-api.28709
+#   and more specifically: https://docs.plesk.com/en-US/12.5/api-rpc/reference.28784
+
+
+# This may be needed if the DNS provider doesn't make the standard Plesk API available to a user.
+# As a result, Plesk can't be configured using usual means or RFC1236. But the XML API is often 
+# still left accessible, and is well documented, so it can be used instead, for acme.sh purposes.
+
+
+# API NOTES:
+
+# 1) The API uses a user/password combination. It should therefore require cURL over HTTPS
+#    with a MAXIMALLY SECURE TLS CIPHER AND GOOD CERT + REVOCATION CHECKS ON THE API URI, 
+#    in (almost) all cases. 
+
+#    Acceptable/valid ciphers and certificate checks can be specified via optional cURL variables (see below).
+#    Note that edge cases may exist where SSL is not yet set up
+#    (e.g. testing Plesk on ones own network), so although highly recommended, this can be OVERRIDDEN.
+
+# 2) --anyauth is used with cURL, to ensure the highest available level of encryption.
+
+# 3) The API references domains by a domain ID, when manipulating records. So the code must 
+#    initially convert domain names (string) to Plesk domain IDs (numeric).
+
+
+# REQUIRED VARIABLES:
+
+# You need to provide the Plesk URI and login (username and password) as follows:
+
+#     export pleskxml_uri="https://www.plesk_uri.org:8443/enterprise/control/agent.php"
+#                         (or something similar)
+#     export pleskxml_user="johndoe"
+#     export pleskxml_pass="kj8we8dej38e8d#q0q3!!!qa"
+
+
+# OPTIONAL VARIABLES:
+
+# To use an insecure Plesk URI, set the following:
+#     export pleskxml_allow_insecure_uri=yes
+
+# Extra cURL args (for certificate handling, timeout etc):
+#     export pleskxml_optional_curl_args=LIST_OF_ARGS
+#                                        (eg =-v   or ="-H 'HEADER STRINGS'")
+
+# Debug level (0/absent=none, 1=all, 2=major msgs only, 3=minimum msgs/most severe only)
+# If debug level is nonzero, all DBG messages equal to or more severe than this, are displayed.
+# By design if DBG level is 9 for a message, it is ALWAYS shown, this is used for _info and _err
+#     export pleskxml_debug_min_level=2
+
+
+############  Before anything else, define dedug functions to be sure they are detected even if while testing #####################
+
+_DBG_EARLY_CHECK_MODE() {
+    
+    if printf '%s' "${pleskxml_debug_min_level:-0}" | grep -qE '^[0-3]$' ; then
+        _pleskxml_DBG_LEVEL="${pleskxml_debug_min_level:-0}"
+        _pleskxml_DBG_COUNT=0
+    else
+        _err "Invalid debug level, exiting. \$pleskxml_debug_min_level = '${pleskxml_debug_min_level}' "
+        return 1
+    fi
+
+    _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_DBG_LEVEL}' "
+        # This won't display if DBG level was set to zero.    
+}
+
+#  arg1 = severity level (1=least serious, 3=most serious)
+# By design if DBG level is 9 for a MESSAGE, the message is ALWAYS shown, this is used for _info and _err
+#  arg2 = message
+_DBG() {
+    if [ "$1" -eq 9 ] || ( [ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_DBG_LEVEL" ] ); then
+        case $1 in
+            1)    _pleskxml_severity='INFO'
+                ;;
+            2)    _pleskxml_severity='WARN'
+                ;;
+            3)    _pleskxml_severity='ERR'
+                ;;
+            9)    _pleskxml_severity='_ACME.SH'
+                ;;
+        esac
+        _pleskxml_DBG_COUNT=$(( _pleskxml_DBG_COUNT + 1 ))
+        printf '%04d DEBUG [%s]:\n%s\n\n' "$_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$2"
+    fi
+}
+
+
+#  arg1 = severity level (1=least serious, 3=most serious)
+#  arg2 = message (vardump will be appended)
+_DBG_VARDUMP() {
+    _DBG "$1" "$( printf '%s: 1st lines of current defined variables are now:\n%s\n\n' "${2:-NO_FURTHER_MSG}" "$( set | grep '_pleskxml' | sort )" )"
+}
+
+
+_DBG_ERR_TRAP() {
+    echo "Error on line $1"
+}
+
+
+
+############ Start of module itself ##############################
+
+
+# Trap errors and perform early check for debug mode.
+# Traps currently ignored
+
+# set -e
+# trap '_DBG_ERR_TRAP ${LINENO:-NO_LINE}' .....
+
+_DBG_EARLY_CHECK_MODE
+
+
+############  Set up static/private variables #####################
+
+
+_pleskxml_curlpath=/usr/local/bin/curl
+
+_pleskxml_newline='
+'
+
+
+# Plesk XML templates. 
+#   Note ALL TEMPLATES MUST HAVE EXACTLY 3 %s PLACEHOLDERS
+#   (otherwise printf repeats the string causing the API call to fail)
+
+_pleskxml_tplt_get_domain_id="<packet><webspace><get><filter><name>%s</name></filter><dataset></dataset></get></webspace></packet>"
+    # Convert domain name to a Plesk internal domain ID
+    # Args:
+    #   the domain name to query
+
+_pleskxml_tplt_add_txt_record="<packet><dns><add_rec><site-id>%s</site-id><type>TXT</type><host>%s</host><value>%s</value></add_rec></dns></packet>"
+    # Adds a TXT record to a domain
+    # Args:
+    #   the Plesk internal domain ID for the domain
+    #   the "host" entry within the domain, to add this to (eg '_acme_challenge')
+    #   the TXT record value
+
+_pleskxml_tplt_rmv_dns_record="<packet><dns><del_rec><filter><id>%s</id></filter></del_rec></dns></packet>"
+    # Adds a TXT record to a domain
+    # Args:
+    #   the Plesk internal ID for the dns record to delete
+
+_pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-id></filter></get_rec></dns></packet>"
+    # Gets all DNS records for a Plesk domain ID
+    # Args:
+    #   the domain id to query
+
+
+############  Define public functions #####################
+
+# Usage: dns_pleskxml_add _acme-challenge.domain.org "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+
+dns_pleskxml_add() {
+
+
+_DBG 2 "Entered dns_pleskxml_add($*)..."
+
+    _pleskxml_FQDN=$1
+    _pleskxml_TXT_string=$2
+    
+    # validate variables set by user.
+    # If valid, then matching internal variables will be set with the appropriate checked values
+    # Otherwise exit with an error
+    
+    _info "Plesk XML: Trying to add a DNS TXT record for acme validation."
+    _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
+    _info "Plesk XML: Checking login and other variables supplied by user"
+
+    _pleskxml_get_variables
+    _pleskxml_retcode=$?
+    
+_DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
+        _err "$_pleskxml_errors"
+        return 1
+    fi
+
+    if [ "$_pleskxml_allow_insecure"  ]; then
+        _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
+    fi
+    
+    # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
+
+    _info "Plesk XML: Variables loaded."
+    _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
+
+_DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
+
+    _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
+    _pleskxml_retcode=$?
+
+_DBG_VARDUMP 2 'Call has returned'
+
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+        _err "$_pleskxml_errors"
+        return 1
+    fi
+
+    # OK, valid response containing a valid domain ID must have been found
+    # If not we should have got an error.
+    
+    # Try to add the TXT record
+
+_DBG 2 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+
+    _info "Plesk XML: Trying to add TXT record to domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'. The TXT string is: '$_pleskxml_TXT_string'."
+
+    _pleskxml_add_dns_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
+    _pleskxml_retcode=$?
+
+_DBG_VARDUMP 2 'Call has returned'
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+        _err "$_pleskxml_errors"
+        return 1
+    fi
+
+    _info 'An ACME Challenge TXT record for '"$_pleskxml_domain"' was added to Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
+    _info "(TO CHECK?: Note that all subdomains under this domain uses the same TXT record.) <-- MAY NOT BE NEEDED"
+
+_DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
+
+    return 0
+}
+
+
+
+# Usage: dns_pleskxml_rm _acme-challenge.domain.org "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+# Remove a TXT record after validation
+
+dns_pleskxml_rm() {
+
+_DBG 2 "Entered dns_pleskxml_rm($*)..."
+
+    _pleskxml_FQDN=$1
+    _pleskxml_TXT_string=$2
+    
+    # validate variables set by user.
+    # If valid, then matching internal variables will be set with the appropriate checked values
+    # Otherwise exit with an error
+    
+    _info "Plesk XML: Trying to remove a recently-added DNS TXT record for following acme validation."
+    _info "Plesk XML: Domain = $_pleskxml_FQDN. DNS TXT string = '$_pleskxml_TXT_string'."
+    _info "Plesk XML: Checking login and other variables supplied by user"
+
+    _pleskxml_get_variables
+    _pleskxml_retcode=$?
+
+_DBG_VARDUMP 2 'Called _pleskxml_get_variables()'
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
+        _err "$_pleskxml_errors"
+        return 1
+    fi
+
+    if [ "$_pleskxml_allow_insecure" ]; then
+        _info 'Plesk XML: You have allowed insecure http connections to Plesk. Passwords and logins may be sent in plain text.\nPlease do not use this setting unless very sure of security!'
+    fi
+    
+    # Try to convert the domain name to a plesk domain ID. This also lets us know if the URI and authentication are OK.
+
+    _info "Plesk XML: Variables loaded."
+    _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
+
+_DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
+
+    _pleskxml_domain_id="$( _pleskxml_get_domain_ID "$_pleskxml_domain" )"
+    _pleskxml_retcode=$?
+
+_DBG_VARDUMP 2 'Call has returned'
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+        _err "$_pleskxml_errors"
+        return 1
+    fi
+
+    # OK, valid response containing a valid domain ID must have been found
+    # If not we should have got an error.
+    
+    # Try to remove the TXT record. First step - get all TXT records
+
+    _info "Plesk XML: Trying to remove TXT record from domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'."
+
+_DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+
+    _pleskxml_rmv_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
+    _pleskxml_retcode=$?
+
+_DBG_VARDUMP 2 'Call has returned'
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+        _err "$_pleskxml_errors"
+        return 1
+    fi
+
+    _info 'A TXT record for '"$_pleskxml_domain"' was removed from Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
+
+_DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
+
+    return 0
+}
+
+####################  Define private functions ##################################
+
+
+####################  Plesk related functions
+
+_pleskxml_get_variables() {
+
+_DBG_VARDUMP 2 'Entered _pleskxml_get_variables()'
+
+    _pleskxml_errors=''
+
+    # The Plesk XML API needs the base domain (mydomain.com) and host (_acme_challenge) split out from the FQDN
+    # supplied to this module, to manage the relevant DNS records
+    # We assume ACME.SH does most of the validation, but even so, let's check some basic character compliance.
+    # Not checking just [a-z0-9] since the FQDN could be unicode, but this should be reasonably sane. 
+    # If not, it'll be over-cautious and block unicode based on bytes, and need fixing.
+    # At most the check can be removed. But it needs to be able to split out a host and a domain.
+
+    if printf '%s' "$_pleskxml_FQDN" | grep -iEq '^[^][/.:[:space:]^$*'\''"`-][^][/.:[:space:]^$*'\''"`]*(\.[^][/.:[:space:]^$*'\''"`_]+)+$'; then
+        _pleskxml_host="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^([^.]+)\..*$/\1/' )"
+        _pleskxml_domain="$( printf '%s' "$_pleskxml_FQDN" | sed -E 's/^[^.]+\.(.*)$/\1/' )"
+    else
+        _pleskxml_errors="An invalid domain name (FQDN) was supplied."
+    fi
+
+    # Now process other variables
+    
+    _pleskxml_allow_insecure="${pleskxml_allow_insecure_uri:-no}"
+    if [ "$_pleskxml_allow_insecure" = "yes" ] || [ "$_pleskxml_allow_insecure" = "Yes" ] || [ "$_pleskxml_allow_insecure" = "YES" ]; then
+        # Allow insecure (non-SSL) URI for Plesk. "s" is optional within the "https" URI
+        _pleskxml_allow_insecure=1
+        _pleskxml_uri_prefix_match='https?://'
+    else
+        # Require secure (SSL) URI for Plesk. "s" is mandatory within the "https" URI
+        _pleskxml_allow_insecure=0
+        _pleskxml_uri_prefix_match='https://'
+    fi
+    
+
+    if printf '%s' "${pleskxml_uri:-}" | grep -qiE "^${_pleskxml_uri_prefix_match}"'([a-z0-9][a-z0-9.:-]*|\[[a-f0-9][a-f0-9.:]+\])(:[0-9]{1,5})?(/|$)'; then
+        # URI is "valid enough" to use, and uses https if this is mandatory (= pleskxml_allow_insecure_uri wasn't set)
+        _pleskxml_uri="$pleskxml_uri"
+    else
+        _pleskxml_errors="$_pleskxml_errors"'\nBad or unacceptable URI (If non-SSL HTTP is required, did you set "pleskxml_allow_insecure_uri"?).\nYou should set and export '"$pleskxml_uri"', containing the URI for your Plesk XML API.\nThe URI usually looks like this: https://my_plesk_uri.tld:8443'
+    fi
+    
+    if printf '%s' "${pleskxml_user:-}" | grep -qiE '^[a-z0-9@%._-]+$'; then
+        # USER is "valid enough" to use - Plesk doesn't stipulate valid chars, but thewse are probably "safe enough". We will find out if they aren't, the hard way :)
+        # Note, we cannot assume "safe" characters when we use this value!
+        _pleskxml_user="$pleskxml_user"
+    else
+        _pleskxml_errors="$_pleskxml_errors"'\nBad or unacceptable USER ACCOUNT for Plesk authentication. You should set and export '"$pleskxml_user."
+    fi
+
+    if [ "${pleskxml_pass:-}" != "" ]; then
+        # PASS is "valid enough" to use - Plesk doesn't stipulate valid chars, but thewse are probably "safe enough". We will find out if they aren't, the hard way :)
+        # Note, we cannot assume "safe" characters when we use this value!
+        _pleskxml_pass="$pleskxml_pass"
+    else
+        _pleskxml_errors="$_pleskxml_errors"'\nEmpty USER PASSWORD for Plesk authentication. You should set and export '"$pleskxml_pass."
+    fi
+    
+    # Ensure if not supplied, optional curl args are an empty string
+    _pleskxml_optional_curl_args="${pleskxml_optional_curl_args:-}"
+
+    if [ -n "$_pleskxml_errors" ]; then
+_DBG_VARDUMP 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
+        return 1
+    else
+_DBG_VARDUMP 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
+        return 0
+    fi
+}
+
+
+
+# Build a cURL request for the Plesk API
+# ARGS:
+# First arg is a Plesk XML API template. Further args (up to 3 items) are substituted into it via printf
+
+_pleskxml_api_request() {
+
+
+_DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
+
+    _pleskxml_errors=''
+    _pleskxml_result=''
+    _pleskxml_prettyprint_result=''
+    _pleskxml_result=''
+
+    # Of all the API commands we use, just one of them can return multiple results sections
+    # so the validation process after cURL returns, will differ for that case.....
+    
+    if [ "$1" = "$_pleskxml_tplt_get_dns_records" ]; then
+        _pleskxml_multiple_results_allowed=1
+    else
+        _pleskxml_multiple_results_allowed=0
+    fi
+
+    # Sanitise user+pw for single quote enclosure, ands build Plesk arg string
+
+    _pleskxml_user="$( printf '%s' "$_pleskxml_user" | sed "s/'/'\\''/g" )"
+    _pleskxml_pass="$( printf '%s' "$_pleskxml_pass" | sed "s/'/'\\''/g" )"
+    _pleskxml_APICMD="$( printf "$1 %0.0s%0.0s%0.0s" "$2" "$3" "$4" )"
+        # Add some %0.0s at the end of the format string in the 1st arg, to cope with ("absorb") variable number of further args
+        # otherwise this will repeat the format string which we don't want.
+        # If there weren't additional args, these will evaluate to empty strings/blank, and be harmless.
+
+    _pleskxml_curlargs="--anyauth \
+               -X POST \
+               -H 'Content-Type: text/xml' \
+               -H 'HTTP_PRETTY_PRINT: TRUE' \
+               -H 'HTTP_AUTH_LOGIN: ${_pleskxml_user}' \
+               -H 'HTTP_AUTH_PASSWD: ${_pleskxml_pass}' \
+               -d '${_pleskxml_APICMD}' \
+               ${_pleskxml_optional_curl_args}"
+
+_DBG_VARDUMP 2 'About to call Plesk via cURL'
+
+_DBG 2 "$( printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" )"
+        _pleskxml_prettyprint_result="$( eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null )"
+        _pleskxml_retcode="$?"
+_DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
+_DBG 2 "retcode = $_pleskxml_retcode"
+
+ # BUGFIX TO CHECK - WILL RETCODE FROM cURL BE AVAILABLE HERE?
+
+    # Abort if cURL failed
+    
+    if [ $_pleskxml_retcode -ne 0 ]; then
+        _pleskxml_errors="Exiting due to cURL error when querying Plesk XML API. The cURL return code was: $_pleskxml_retcode."
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+    
+    # OK. Next, check XML reply was OK. Start by pushing it into one line, with leading/trailing space trimmed.
+
+#    _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
+#            awk '{$1=$1};1' | \
+#            tr -d '\n' \
+#            )"
+
+    _pleskxml_result="$( printf '%s' "$_pleskxml_prettyprint_result" | \
+            sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
+            tr -d '\n' \
+            )"
+
+_DBG_VARDUMP 2 'cURL succeeded, valid cURL response obtained'
+
+    # Now we need to check item by item if it's OK. 
+    # As we go, we will strip out "known OK" stuff to leave the core reply.
+    
+    # XML header and packet version?
+
+_DBG 2 'Checking <?xml> and <packet> tags exist...'
+
+    if printf '%s' "$_pleskxml_result" | grep -qiEv '^<\?xml version=[^>]+><packet version=[^>]+>.*</packet>$'; then
+        # Error - should have <?xml><packet>...</packet>. Abort
+        _pleskxml_errors="Error when querying Plesk XML API. The API did not return a valid XML response. The response was:${_pleskxml_newline}${_pleskxml_prettyprint_result}${_pleskxml_newline}The collapsed version was:${_pleskxml_newline}'${_pleskxml_result}'${_pleskxml_newline}"
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    else
+        # So far so good. Strip the <?xml> and <packet>...</packet> tags and continue
+        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+                sed -E 's/^<\?xml version[^>]+><packet version[^>]+>(.*)<\/packet>$/\1/' \
+                )"
+    fi
+
+_DBG 2 "Checking <system> tags don't exist..."
+
+    # <system> section found anywhere in response?
+    # This usually means some kind of basic API error such as login failure, bad XML request, etc
+    
+
+    if printf '%s' "$_pleskxml_result" | grep -qiE '<system>.*</system>'; then
+        # Error - shouldn't contain <system>...</system>. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The result contained a <system> tag.\nThis usually indicates an invalid login, badly formatted API request or other error. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+
+_DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
+
+    
+    # Check results section. Most commands only have one results section. 
+    # But some (i.e., get all DNS records for a domain) have many results sections,
+    # and we will need to check each <results>...</results> section separately.
+    # So this gets a bit messy, especially as we don't have non-greedy regex
+    # and we will have to work around that as well.
+
+    # For this, we will split the string up again with exactly 1 <result> section per line.
+    # We check there is at least one result section. Then we add newlines before and after 
+    # any <result>...</result> and ignore any lines that don't contain '<result>'.
+
+    if printf '%s' "$_pleskxml_result" | grep -qiEv '<result>.*</result>'; then
+        # Error - doesn't contain <result>...</result>. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The result did not contain a <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+_DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
+
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+        sed "s/<result>/\\${_pleskxml_newline}<result>/g" | \
+        sed "s/<\/result>/<\/result>\\${_pleskxml_newline}/g" | \
+        grep '<result>' \
+         )"
+
+    # Detect and abort if there are >1 <result> sections and we're ponly expecting 1 section.
+    
+    _pleskxml_linecount=$( printf '%s\n' "$_pleskxml_result" | wc -l )
+
+_DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
+
+_DBG_VARDUMP 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
+    
+    if [ $_pleskxml_multiple_results_allowed -eq 0 ] && [ "$_pleskxml_linecount" -gt 1 ]; then
+        # Error - contains multiple <result> sections. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The result contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+_DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
+    
+    # Loop through each <result> section, checking every line has exactly one result section, 
+    # containing exactly one status section, which contains <status>ok</status>
+
+    while IFS= read -r _pleskxml_line; do
+
+        # _pleskxml_line *should* contain a single result section.
+        # Check this is correct.
+        
+
+# _DBG "Checking a <result> section... content is ${_pleskxml_line}"
+
+        if printf '%s' "$_pleskxml_line" | grep -qiEv '^<result>.*</result>$'; then
+            # Error - doesn't contain <result>...</result>. Abort
+            _pleskxml_errors='Error when querying Plesk XML API. A <result> section was not found where expected.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+            return 1
+        fi
+    
+        # Now strip the <results> tag and check there is precisely one <status> section and its ciontents are "ok"
+        
+        _pleskxml_line="$( printf '%s' "$_pleskxml_line" | sed -E 's/^<result>(.*)<\/result>$/\1/' )"
+
+        if printf '%s' "$_pleskxml_line" | grep -qiEv '<status>.*</status>'; then
+            # Error - doesn't contain <status>...</status>. Abort
+            _pleskxml_errors='Error when querying Plesk XML API. A <result> section did not contain a <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+            return 1
+        elif printf '%s' "$_pleskxml_line" | grep -qiE '<status>.*</status>.*<status>'; then
+            # Error - contains <status>...</status>...<status>. Abort
+            _pleskxml_errors='Error when querying Plesk XML API. A <result> section contained more than one <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+            return 1
+        elif printf '%s' "$_pleskxml_line" | grep -qiEv '<status>ok</status>'; then
+            # Error - doesn't contain <status>ok</status>. Abort
+            _pleskxml_errors='Error when querying Plesk XML API. A <status> tag did not contain "<status>ok</status>". The response was:\n'"$_pleskxml_prettyprint_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+            return 1
+        fi
+
+# _DBG "Line is OK. Looping to next line or exiting..."
+
+    done << EOL
+$_pleskxml_result
+EOL
+
+    # So far so good. Remove all <status>ok</status> sections as they're checked now.
+
+_DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
+
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+            sed -E 's/<status>ok<\/status>//g' \
+            )"
+
+    # Result is OK. Remove any redundant self-closing tags, and <data> or </data> tags, and exit
+
+_DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
+
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+            sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g' \
+            )"
+
+_DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
+
+_DBG_VARDUMP 2 'Successfully exiting Plesk XML API function'
+
+    return 0
+    
+}
+
+
+
+
+_pleskxml_get_domain_ID() {
+
+_DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
+
+    # Call cURL to convert a domain name to a plesk domain ID.
+
+_DBG 2 'About to make API request (domain name -> domain ID)'
+
+    _pleskxml_api_request "$_pleskxml_tplt_get_domain_id" "$1"
+    _pleskxml_retcode=$?
+        # $1 is the domain name we wish to convert to a Plesk domain ID
+    
+_DBG 2 'Returned from API request, now back in get_domain_ID()'
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+    # OK, we should have a domain ID. Let's check and return it if so.
+    
+    # Result should comprise precisely one <result> section
+    
+_DBG 2 'Testing API return data for one <result> and removing if so'
+
+    if printf '%s' "$_pleskxml_result" | grep -qiEv '^<result>.*</result>$'; then
+        # Error - doesn't comprise <result>DOMAINNAME</result>. Something's wrong. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The API did not comprise a <result> section containing all other data.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    elif printf '%s' "$_pleskxml_result" | grep -qiE '<result>.*<result>'; then
+        # Error - contains <result>...</result>...<result>. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    else
+        # So far so good. Remove the <result>...</result> section and continue
+        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+                sed -E 's/(^<result>|<\/result>$)//g' \
+                )"
+    fi
+
+    # Result should contain precisely one <filter-id> section, containing the domain name inquired.
+    
+_DBG 2 'Testing API return data for one <filter-id> and removing if so'
+
+    if printf '%s' "$_pleskxml_result" | grep -qiv "<filter-id>$1</filter-id>"; then
+        # Error - doesn't contain <filter-id>DOMAINNAME</filter-id>. Something's wrong. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <filter-id> section containing the domain name.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    elif printf '%s' "$_pleskxml_result" | grep -qiE '<filter-id>.*<filter-id>'; then
+        # Error - contains <filter-id>...</filter-id>...<filter-id>. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <filter-id> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    else
+        # So far so good. Remove the <filter-id>...</filter-id> section and continue
+        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+                sed "s/<filter-id>$1<\/filter-id>//" \
+                )"
+    fi
+
+    # All that should be left is one section, containing <id>DOMAIN_ID</id>
+    
+_DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
+
+    if printf '%s' "$_pleskxml_result" | grep -qiEv '^<id>[0-9]+</id>$'; then
+        # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The API did not contain the expected <id>[NUMERIC_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+    
+    # SUCCESS! Remove the surrounding <id> tag and return the value!
+
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+            sed -E 's/^<id>([0-9]+)<\/id>$/\1/' \
+            )"
+
+_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
+
+    return 0    
+
+}
+
+
+# 1st arg is the domain ID
+# 2nd arg (optional) is the TYPE of arg(s) to keep
+#   format = valid regex WITHOUT ^ or $, such as TXT, or (A|AAAA|CNAME)
+
+_pleskxml_get_dns_records() {
+
+_DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
+
+    # First, we need to get all DNS records, and check the list is valid
+
+_DBG 2 'About to make API request (get DNS records)'
+
+    _pleskxml_api_request "$_pleskxml_tplt_get_dns_records" "$1"
+    _pleskxml_retcode=$?
+        # $1 is the Plesk internal domain ID for the domain
+    
+_DBG 2 'Returned from API request, now back in get_txt_records()'
+
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+    # OK, we should have a <result> section containing a list of DNS records.
+    # Now keep only the TXT records
+
+
+_DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+
+    if [ -n "${2:-}" ]; then
+        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+                grep "<type>$2</type>" \
+                )"
+_DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+    else
+_DBG 2 'Not filtering DNS records. All records will be returned.'
+    fi
+    
+_DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
+    return 0
+}
+
+
+
+_pleskxml_add_txt_record() {
+
+_DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
+
+_DBG 2 'About to make API request (add TXT record)'
+
+    _pleskxml_api_request "$_pleskxml_tplt_add_txt_record" "$1" "$2" "$3"
+    _pleskxml_retcode=$?
+
+        # $1 is the Plesk internal domain ID for the domain
+        # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
+        # $3 is the TXT record value
+
+_DBG 2 'Returned from API request, now back in add_txt_record()'
+    
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+    # OK, we should have added a TXT record. Let's check and return success if so.
+    # All that should be left in the result, is one section, containing <result><id>PLESK_NEW_DNS_RECORD_ID</id></result>
+    
+    if printf '%s' "$_pleskxml_result" | grep -qivE '^<result><id>[0-9]+</id></result>$'; then
+        # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
+        _pleskxml_errors='Error when calling Plesk XML API. The API did not contain the expected <id>[PLESK_NEW_DNS_RECORD_ID]</id> section, or contained other unexpected values as well.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+    
+    # SUCCESS! Remove the surrounding <result><id> tags and return the value!
+    # (although we don't actually use it!
+
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+            sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/" \
+            )"
+
+_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
+
+    return 0    
+}
+
+_pleskxml_rmv_dns_record() {
+
+_DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
+
+_DBG 2 'About to make API request (rmv TXT record)'
+
+    _pleskxml_api_request "$_pleskxml_tplt_rmv_dns_record" "$1"
+    _pleskxml_retcode=$?
+
+        # $1 is the Plesk internal domain ID for the TXT record
+
+_DBG 2 'Returned from API request, now back in rmv_dns_record()'
+    
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+    # OK, we should have removed a TXT record. If it failed, there wouldn't have been a "status:ok" above
+
+_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
+
+    return 0    
+}
+
+
+# 1st arg = domain ID
+# 2nd arg = host that the record exists for
+# 3rd arg = value of TXT record string to be found and removed
+_pleskxml_rmv_txt_record() {
+
+
+_DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
+
+    _pleskxml_get_dns_records "$1" 'TXT'
+    _pleskxml_retcode=$?
+        # $1 is the Plesk internal domain ID for the domain
+    
+_DBG 2 'Returned from API request, now back in rmv_txt_record()'
+
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+    # OK, we should have a <result> section containing a list of DNS TXT records.
+    # Now we need to find our desired record in it (if it exists).
+    # and might as well collapse any successful matches to a signle line for line-count purposes at the same time
+
+_DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
+
+    _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+            grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." | \
+            grep -F "<value>${3:-<NON_MATCHING_GARBAGE>}</value>" | \
+            sed -E 's/(^[[:space:]]+|[[:space:]]+$)//g' | \
+            tr -d '\n' \
+            )"
+        # Run 2 separate GREP filters, because the host and value order isn't mandatory in the API return data
+        # ands this avoids regex and escaping which is easier
+        # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
+
+_DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
+
+    if printf '%s' "$_pleskxml_result" | grep -qiE "<result>.*<result>"; then
+        # Error - contains <result>...</result>...<result>. Abort
+        _pleskxml_errors='Error when querying Plesk XML API. The API contained more than one <result> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\nand the exact test string was:\n'"$_pleskxml_result"'\n'
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+    
+    if printf '%s\n' "$_pleskxml_result" | grep -qiv "<result>"; then
+        # No matching TXT records, so we're done.
+        _info "Couldn't find a TXT record matching the requested host/value. Not an error, but a concern..."
+_DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
+        _pleskxml_result=''
+        return 0
+    fi
+
+    # If we get here, there was a single TXT record match, so we delete it.
+
+        _pleskxml_result="$( printf '%s' "$_pleskxml_result" | \
+                sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/' \
+                )"
+
+_DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
+
+    _pleskxml_rmv_dns_record "$_pleskxml_result"
+    _pleskxml_retcode=$?
+    
+_DBG 2 'Returned from API request, now back in rmv_txt_record()'
+
+    if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
+        # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
+_DBG 2 "$_pleskxml_errors"
+        return 1
+    fi
+
+_DBG_VARDUMP 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
+
+    return 0    
+}
+
+
+exit
+
+# ---------------------- TEST CODE ------------------------------
+
+
+# defined by user 
+    pleskxml_uri="https://plesk.XXXXX.net:8443/enterprise/control/agent.php"
+    pleskxml_user="XXXXX"
+    pleskxml_pass="XXXXX"
+    pleskxml_debug_min_level=3
+    
+# defined from args by module
+    _pleskxml_FQDN="_acme_challenge.XXXXX.com"
+    _pleskxml_TXT_string='~test~string~'
+    
+printf '\n\n\n\n======================================================================== START OF RUN\n\n'
+
+_info 'Checking debug mode...'
+
+_DBG_EARLY_CHECK_MODE
+
+_DBG 3 'Debug mode done. Now testing _pleskxml_get_variables()'
+
+_pleskxml_get_variables
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG 3 '==============================================================='
+
+_DBG 3 'Testing _pleskxml_get_domain_ID()'
+_pleskxml_get_domain_ID "atticflat.uk"
+
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG_VARDUMP 2
+
+_DBG 3 '==============================================================='
+
+test_string="TEST STRING ADDED @ $( date )"
+
+_DBG 3 "Testing add a TXT string: '$test_string' "
+_pleskxml_add_txt_record 874 '_test_subdomain' "$test_string"
+
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG_VARDUMP 2
+
+_DBG 3 '==============================================================='
+
+_DBG 3 'Testing get DNS records (ALL)'
+_pleskxml_get_dns_records 874
+
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG_VARDUMP 2
+
+_DBG 3 '==============================================================='
+
+_DBG 3 'Testing get DNS records (TXT ONLY)'
+_pleskxml_get_dns_records 874 TXT
+
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG_VARDUMP 2
+
+_DBG 3 '==============================================================='
+
+_DBG 3 'Testing rmv a TXT string'
+_pleskxml_rmv_txt_record 874 '_test_subdomain' "$test_string"
+
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG_VARDUMP 2
+
+_DBG 3 '==============================================================='
+
+_DBG 3 'Re-testing get DNS records (TXT ONLY) after TXT string removal'
+_pleskxml_get_dns_records 874 TXT
+
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG_VARDUMP 2
+
+_DBG 3 '==============================================================='
+
+_DBG 3 'Testing rmv a TXT string, with a non-matching string'
+_pleskxml_rmv_txt_record 874 '_test_subdomain' 'JUNKegqw4bw4bb2'
+
+_DBG 3 "$( printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result" )"
+
+_DBG_VARDUMP 2
+
+_DBG 3 '=============================================================== END OF RUN'

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -56,18 +56,18 @@
 
 ############  Before anything else, define dedug functions to be sure they are detected even if while testing #####################
 
-_DBG_EARLY_CHECK_MODE() {
+_pleskxml_DBG_EARLY_CHECK_MODE() {
 
   if printf '%s' "${pleskxml_debug_min_level:-0}" | grep -qE '^[0-3]$'; then
-    _pleskxml_DBG_LEVEL="${pleskxml_debug_min_level:-0}"
-    _pleskxml_DBG_COUNT=0
+    _pleskxml_pleskxml_DBG_LEVEL="${pleskxml_debug_min_level:-0}"
+    _pleskxml_pleskxml_DBG_COUNT=0
   else
     _err "Invalid debug level, exiting. \$pleskxml_debug_min_level = '${pleskxml_debug_min_level}' "
     return 1
   fi
 
-  if [ "$_pleskxml_DBG_LEVEL" -gt 0 ]; then
-    _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_DBG_LEVEL}' "
+  if [ "$_pleskxml_pleskxml_DBG_LEVEL" -gt 0 ]; then
+    _info "plesk XML running in debug mode. Debug level =  '${_pleskxml_pleskxml_DBG_LEVEL}' "
     # This won't display if DBG level was set to zero.
   fi
 }
@@ -75,25 +75,25 @@ _DBG_EARLY_CHECK_MODE() {
 # arg1 = severity level (1=least serious, 3=most serious)
 #   By design if DBG level is 9 for a MESSAGE, the message is ALWAYS shown, this is used for _info and _err
 # arg2 = message
-_DBG() {
-  if [ "$1" -eq 9 ] || ([ "$_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_DBG_LEVEL" ]); then
+_pleskxml_DBG() {
+  if [ "$1" -eq 9 ] || ([ "$_pleskxml_pleskxml_DBG_LEVEL" -gt 0 ] && [ "$1" -ge "$_pleskxml_pleskxml_DBG_LEVEL" ]); then
     case $1 in
       1) _pleskxml_severity='MAX_DETAIL' ;;
       2) _pleskxml_severity='DETAIL' ;;
       3) _pleskxml_severity='INFO' ;;
       9) _pleskxml_severity='ACME.SH' ;;
     esac
-    _pleskxml_DBG_COUNT=$((_pleskxml_DBG_COUNT + 1))
-    printf '%04d DEBUG [%s/%d]:\n%s\n\n' "$_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$1" "$2"
+    _pleskxml_pleskxml_DBG_COUNT=$((_pleskxml_pleskxml_DBG_COUNT + 1))
+    printf '%04d DEBUG [%s/%d]:\n%s\n\n' "$_pleskxml_pleskxml_DBG_COUNT" "$_pleskxml_severity" "$1" "$2"
   fi
 }
 
 # arg1 = severity level (1=least serious, 3=most serious)
-_DBG_VARDUMP() {
-  _DBG "$1" "$(printf '1st lines of current defined variables are now:\n%s\n\n' "$(set | grep '_pleskxml' | sort)")"
+_pleskxml_DBG_VARDUMP() {
+  _pleskxml_DBG "$1" "$(printf '1st lines of current defined variables are now:\n%s\n\n' "$(set | grep '_pleskxml' | sort)")"
 }
 
-_DBG_ERR_TRAP() {
+_pleskxml_DBG_ERR_TRAP() {
   echo "Error on line $1"
 }
 
@@ -103,9 +103,9 @@ _DBG_ERR_TRAP() {
 # Traps currently ignored
 
 # set -e
-# trap '_DBG_ERR_TRAP ${LINENO:-NO_LINE}' .....
+# trap '_pleskxml_DBG_ERR_TRAP ${LINENO:-NO_LINE}' .....
 
-_DBG_EARLY_CHECK_MODE
+_pleskxml_DBG_EARLY_CHECK_MODE
 
 ############  Set up static/private variables #####################
 
@@ -146,7 +146,7 @@ _pleskxml_tplt_get_dns_records="<packet><dns><get_rec><filter><site-id>%s</site-
 
 dns_pleskxml_add() {
 
-  _DBG 3 "Entered dns_pleskxml_add($*)..."
+  _pleskxml_DBG 3 "Entered dns_pleskxml_add($*)..."
 
   _pleskxml_FQDN="$1"
   _pleskxml_TXT_string="$2"
@@ -161,8 +161,8 @@ dns_pleskxml_add() {
   _pleskxml_get_variables
   _pleskxml_retcode=$?
 
-  _DBG 3 'Returned from _pleskxml_get_variables(). Back in dns_pleskxml_add().'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 3 'Returned from _pleskxml_get_variables(). Back in dns_pleskxml_add().'
+  _pleskxml_DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
     _err "$_pleskxml_errors"
@@ -178,13 +178,13 @@ dns_pleskxml_add() {
   _info "Plesk XML: Variables are valid and loaded."
   _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-  _DBG 3 "Calling API to get domain ID for $_pleskxml_domain"
+  _pleskxml_DBG 3 "Calling API to get domain ID for $_pleskxml_domain"
 
   _pleskxml_get_domain_ID "$_pleskxml_domain"
   _pleskxml_retcode=$?
 
-  _DBG 3 'Returned from API call. Back in dns_pleskxml_add().'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 3 'Returned from API call. Back in dns_pleskxml_add().'
+  _pleskxml_DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -197,15 +197,15 @@ dns_pleskxml_add() {
 
   # Try to add the TXT record
 
-  _DBG 3 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+  _pleskxml_DBG 3 "Calling API to add TXT record to domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
   _info "Plesk XML: Got ID for domain. Trying to add TXT record to domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'. The TXT string is: '$_pleskxml_TXT_string'."
 
   _pleskxml_add_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
   _pleskxml_retcode=$?
 
-  _DBG 3 'Call has returned. dns_pleskxml_add().'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 3 'Call has returned. dns_pleskxml_add().'
+  _pleskxml_DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -215,7 +215,7 @@ dns_pleskxml_add() {
 
   _info 'An ACME Challenge TXT record for '"$_pleskxml_domain"' was added to Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
 
-  _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
+  _pleskxml_DBG 2 "SUCCESSFULLY exiting dns_pleskxml_add()..."
 
   return 0
 }
@@ -225,7 +225,7 @@ dns_pleskxml_add() {
 
 dns_pleskxml_rm() {
 
-  _DBG 2 "Entered dns_pleskxml_rm($*)..."
+  _pleskxml_DBG 2 "Entered dns_pleskxml_rm($*)..."
 
   _pleskxml_FQDN="$1"
   _pleskxml_TXT_string="$2"
@@ -240,8 +240,8 @@ dns_pleskxml_rm() {
   _pleskxml_get_variables
   _pleskxml_retcode=$?
 
-  _DBG 2 'Called _pleskxml_get_variables()'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'Called _pleskxml_get_variables()'
+  _pleskxml_DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ]; then
     _err "$_pleskxml_errors"
@@ -257,13 +257,13 @@ dns_pleskxml_rm() {
   _info "Plesk XML: Variables are valid and loaded."
   _info "Trying to connect to Plesk ($_pleskxml_uri), and request Plesk's internal reference ID for domain '${_pleskxml_domain}'"
 
-  _DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
+  _pleskxml_DBG 2 "Calling API to get domain ID for $_pleskxml_domain"
 
   _pleskxml_get_domain_ID "$_pleskxml_domain"
   _pleskxml_retcode=$?
 
-  _DBG 2 'Call has returned'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'Call has returned'
+  _pleskxml_DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -278,13 +278,13 @@ dns_pleskxml_rm() {
 
   _info "Plesk XML: Got ID for domain. Trying to remove TXT record from domain ID $_pleskxml_domain_id ('$_pleskxml_domain'), host '$_pleskxml_host'."
 
-  _DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
+  _pleskxml_DBG 2 "Calling API to remove TXT record from domain ID #$_pleskxml_domain_id ('$_pleskxml_domain')"
 
   _pleskxml_rmv_txt_record "$_pleskxml_domain_id" "$_pleskxml_host" "$_pleskxml_TXT_string"
   _pleskxml_retcode=$?
 
-  _DBG 2 'Call has returned'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'Call has returned'
+  _pleskxml_DBG_VARDUMP 2
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -294,7 +294,7 @@ dns_pleskxml_rm() {
 
   _info 'A TXT record for '"$_pleskxml_domain"' was removed from Plesk. Plesk returned a successful response.\nThe TXT field was: '"'$_pleskxml_TXT_string'"
 
-  _DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
+  _pleskxml_DBG 2 "SUCCESSFULLY exiting dns_pleskxml_rm()..."
 
   return 0
 }
@@ -305,8 +305,8 @@ dns_pleskxml_rm() {
 
 _pleskxml_get_variables() {
 
-  _DBG 2 'Entered _pleskxml_get_variables()'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'Entered _pleskxml_get_variables()'
+  _pleskxml_DBG_VARDUMP 2
 
   _pleskxml_errors=''
 
@@ -364,13 +364,13 @@ _pleskxml_get_variables() {
   _pleskxml_optional_curl_args="${pleskxml_optional_curl_args:-}"
 
   if [ "$_pleskxml_errors" != '' ]; then
-    _DBG 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
-    _DBG_VARDUMP 2
+    _pleskxml_DBG 2 "UNSUCCESSFULLY exiting _pleskxml_get_variables() (UNSUCCESSFUL CALL!)"
+    _pleskxml_DBG_VARDUMP 2
     _err 'Can'\''t parse user-defined variables. Exiting.'
     return 1
   else
-    _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
-    _DBG_VARDUMP 2
+    _pleskxml_DBG 2 "SUCCESSFULLY exiting _pleskxml_get_variables()"
+    _pleskxml_DBG_VARDUMP 2
     return 0
   fi
 }
@@ -381,7 +381,7 @@ _pleskxml_get_variables() {
 
 _pleskxml_api_request() {
 
-  _DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
+  _pleskxml_DBG 2 "Entered _pleskxml_api_request($*), to make an XML request.${_pleskxml_newline}  arg1=^$1^${_pleskxml_newline}  arg2=^$2^${_pleskxml_newline}  arg3=^$3^${_pleskxml_newline}  arg4=^$4^"
 
   _pleskxml_errors=''
   _pleskxml_result=''
@@ -415,14 +415,14 @@ _pleskxml_api_request() {
          -d '${_pleskxml_APICMD}' \
          ${_pleskxml_optional_curl_args}"
 
-  _DBG 2 'About to call Plesk via cURL'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'About to call Plesk via cURL'
+  _pleskxml_DBG_VARDUMP 2
 
-  _DBG 2 "$(printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri")"
+  _pleskxml_DBG 2 "$(printf 'cURL command: %s %s %s' "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri")"
   _pleskxml_prettyprint_result="$(eval "$_pleskxml_curlpath" "$_pleskxml_curlargs" "$_pleskxml_uri" 2>/dev/null)"
   _pleskxml_retcode="$?"
-  _DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
-  _DBG 2 "retcode = $_pleskxml_retcode"
+  _pleskxml_DBG 1 "_pleskxml_prettyprint_result =${_pleskxml_newline}'$_pleskxml_prettyprint_result' "
+  _pleskxml_DBG 2 "retcode = $_pleskxml_retcode"
 
   # BUGFIX TO CHECK - WILL RETCODE FROM cURL BE AVAILABLE HERE?
 
@@ -446,15 +446,15 @@ _pleskxml_api_request() {
     | tr -d '\n'
   )"
 
-  _DBG 2 'cURL succeeded, valid cURL response obtained'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'cURL succeeded, valid cURL response obtained'
+  _pleskxml_DBG_VARDUMP 2
 
   # Now we need to check item by item if it's OK.
   # As we go, we will strip out "known OK" stuff to leave the core reply.
 
   # XML header and packet version?
 
-  _DBG 2 'Checking <?xml> and <packet> tags exist...'
+  _pleskxml_DBG 2 'Checking <?xml> and <packet> tags exist...'
 
   if printf '%s' "$_pleskxml_result" | grep -qiEv '^<\?xml version=[^>]+><packet version=[^>]+>.*</packet>$'; then
     # Error - should have <?xml><packet>...</packet>. Abort
@@ -468,7 +468,7 @@ _pleskxml_api_request() {
     )"
   fi
 
-  _DBG 2 "Checking <system> tags don't exist..."
+  _pleskxml_DBG 2 "Checking <system> tags don't exist..."
 
   # <system> section found anywhere in response?
   # This usually means some kind of basic API error such as login failure, bad XML request, etc
@@ -480,7 +480,7 @@ _pleskxml_api_request() {
     return 1
   fi
 
-  _DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
+  _pleskxml_DBG 2 'Checking 1 or >=1 <result> tag (or tags) found, each containing 'status:ok'...'
 
   # Check results section. Most commands only have one results section.
   # But some (i.e., get all DNS records for a domain) have many results sections,
@@ -499,7 +499,7 @@ _pleskxml_api_request() {
     return 1
   fi
 
-  _DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
+  _pleskxml_DBG 2 'Found at least 1 <result> section. Splitting each result section to a separate line'
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | sed "s/<result>/\\${_pleskxml_newline}<result>/g" \
@@ -511,10 +511,10 @@ _pleskxml_api_request() {
 
   _pleskxml_linecount=$(printf '%s\n' "$_pleskxml_result" | wc -l)
 
-  _DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
+  _pleskxml_DBG 2 "Result is: '$_pleskxml_result' (${_pleskxml_linecount} line(s))"
 
-  _DBG 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'Testing <result> section linecount is OK (1 or >=1 as required)'
+  _pleskxml_DBG_VARDUMP 2
 
   if [ $_pleskxml_multiple_results_allowed -eq 0 ] && [ "$_pleskxml_linecount" -gt 1 ]; then
     # Error - contains multiple <result> sections. Abort
@@ -523,7 +523,7 @@ _pleskxml_api_request() {
     return 1
   fi
 
-  _DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
+  _pleskxml_DBG 2 "Found ${_pleskxml_linecount} <result> section(s), checking each has status:ok..."
 
   # Loop through each <result> section, checking every line has exactly one result section,
   # containing exactly one status section, which contains <status>ok</status>
@@ -533,7 +533,7 @@ _pleskxml_api_request() {
     # _pleskxml_line *should* contain a single result section.
     # Check this is correct.
 
-    # _DBG "Checking a <result> section... content is ${_pleskxml_line}"
+    # _pleskxml_DBG "Checking a <result> section... content is ${_pleskxml_line}"
 
     if printf '%s' "$_pleskxml_line" | grep -qiEv '^<result>.*</result>$'; then
       # Error - doesn't contain <result>...</result>. Abort
@@ -549,12 +549,12 @@ _pleskxml_api_request() {
     if printf '%s' "$_pleskxml_line" | grep -qiEv '<status>.*</status>'; then
       # Error - doesn't contain <status>...</status>. Abort
       _pleskxml_errors='Error when querying Plesk XML API. A <result> section did not contain a <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-      _DBG 2 "$_pleskxml_errors"
+      _pleskxml_DBG 2 "$_pleskxml_errors"
       return 1
     elif printf '%s' "$_pleskxml_line" | grep -qiE '<status>.*</status>.*<status>'; then
       # Error - contains <status>...</status>...<status>. Abort
       _pleskxml_errors='Error when querying Plesk XML API. A <result> section contained more than one <status> section.\nThis is unexpected: something has gone wrong. Please raise this as a bug/issue in the module. The response was:\n'"$_pleskxml_prettyprint_result"'\n'
-      _DBG 2 "$_pleskxml_errors"
+      _pleskxml_DBG 2 "$_pleskxml_errors"
       return 1
     elif printf '%s' "$_pleskxml_line" | grep -qiEv '<status>ok</status>'; then
       # Error - doesn't contain <status>ok</status>. Abort
@@ -563,7 +563,7 @@ _pleskxml_api_request() {
       return 1
     fi
 
-    # _DBG "Line is OK. Looping to next line or exiting..."
+    # _pleskxml_DBG "Line is OK. Looping to next line or exiting..."
 
   done <<EOL
 $_pleskxml_result
@@ -571,7 +571,7 @@ EOL
 
   # So far so good. Remove all <status>ok</status> sections as they're checked now.
 
-  _DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
+  _pleskxml_DBG 2 "All results lines had status:ok. Exiting loop,  and removing all <status>ok</status> tags now they've been checked"
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | sed -E 's/<status>ok<\/status>//g'
@@ -579,16 +579,16 @@ EOL
 
   # Result is OK. Remove any redundant self-closing tags, and <data> or </data> tags, and exit
 
-  _DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
+  _pleskxml_DBG 2 'Now removing any self-closing tags, or <data>...</data> tags'
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | sed -E 's/(<[a-zA-Z0-9._-]+[[:space:]]*\/>|<\/?data\/?>)//g'
   )"
 
-  _DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
+  _pleskxml_DBG 2 "About to exit API function. Result = ${_pleskxml_newline}'${_pleskxml_result}' "
 
-  _DBG 2 'Successfully exiting Plesk XML API function'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'Successfully exiting Plesk XML API function'
+  _pleskxml_DBG_VARDUMP 2
 
   return 0
 
@@ -596,17 +596,17 @@ EOL
 
 _pleskxml_get_domain_ID() {
 
-  _DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
+  _pleskxml_DBG 2 "Entered Plesk get_domain_ID($*), to get the domain's Plesk ID."
 
   # Call cURL to convert a domain name to a plesk domain ID.
 
-  _DBG 2 'About to make API request (domain name -> domain ID)'
+  _pleskxml_DBG 2 'About to make API request (domain name -> domain ID)'
 
   _pleskxml_api_request "$_pleskxml_tplt_get_domain_id" "$1"
   _pleskxml_retcode=$?
   # $1 is the domain name we wish to convert to a Plesk domain ID
 
-  _DBG 2 'Returned from API request, now back in get_domain_ID()'
+  _pleskxml_DBG 2 'Returned from API request, now back in get_domain_ID()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -618,7 +618,7 @@ _pleskxml_get_domain_ID() {
 
   # Result should comprise precisely one <result> section
 
-  _DBG 2 'Testing API return data for one <result> and removing if so'
+  _pleskxml_DBG 2 'Testing API return data for one <result> and removing if so'
 
   if printf '%s' "$_pleskxml_result" | grep -qiEv '^<result>.*</result>$'; then
     # Error - doesn't comprise <result>DOMAINNAME</result>. Something's wrong. Abort
@@ -639,7 +639,7 @@ _pleskxml_get_domain_ID() {
 
   # Result should contain precisely one <filter-id> section, containing the domain name inquired.
 
-  _DBG 2 'Testing API return data for one <filter-id> and removing if so'
+  _pleskxml_DBG 2 'Testing API return data for one <filter-id> and removing if so'
 
   if printf '%s' "$_pleskxml_result" | grep -qiv "<filter-id>$1</filter-id>"; then
     # Error - doesn't contain <filter-id>DOMAINNAME</filter-id>. Something's wrong. Abort
@@ -660,7 +660,7 @@ _pleskxml_get_domain_ID() {
 
   # All that should be left is one section, containing <id>DOMAIN_ID</id>
 
-  _DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
+  _pleskxml_DBG 2 "Remaining part of result is now: '$_pleskxml_result' "
 
   if printf '%s' "$_pleskxml_result" | grep -qiEv '^<id>[0-9]+</id>$'; then
     # Error - doesn't contain just <id>NUMBERS</id>. Something's wrong. Abort
@@ -677,8 +677,8 @@ _pleskxml_get_domain_ID() {
 
   _pleskxml_domain_id="$_pleskxml_result"
 
-  _DBG 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'SUCCESSFULLY exiting Plesk get_domain_ID'
+  _pleskxml_DBG_VARDUMP 2
 
   return 0
 
@@ -690,17 +690,17 @@ _pleskxml_get_domain_ID() {
 
 _pleskxml_get_dns_records() {
 
-  _DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
+  _pleskxml_DBG 2 "Entered Plesk _pleskxml_get_dns_records($*)"
 
   # First, we need to get all DNS records, and check the list is valid
 
-  _DBG 2 'About to make API request (get DNS records)'
+  _pleskxml_DBG 2 'About to make API request (get DNS records)'
 
   _pleskxml_api_request "$_pleskxml_tplt_get_dns_records" "$1"
   _pleskxml_retcode=$?
   # $1 is the Plesk internal domain ID for the domain
 
-  _DBG 2 'Returned from API request, now back in get_txt_records()'
+  _pleskxml_DBG 2 'Returned from API request, now back in get_txt_records()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -711,26 +711,26 @@ _pleskxml_get_dns_records() {
   # OK, we should have a <result> section containing a list of DNS records.
   # Now keep only the TXT records
 
-  _DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+  _pleskxml_DBG 2 "Full DNS records were:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
 
   if [ -n "${2:-}" ]; then
     _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
       | grep "<type>$2</type>"
     )"
-    _DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
+    _pleskxml_DBG 2 "Filtered relevant DNS records. Records to be returned are:${_pleskxml_newline}${_pleskxml_newline}'${_pleskxml_result}' "
   else
-    _DBG 2 'Not filtering DNS records. All records will be returned.'
+    _pleskxml_DBG 2 'Not filtering DNS records. All records will be returned.'
   fi
 
-  _DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
+  _pleskxml_DBG 2 "SUCCESSFULLY exiting _pleskxml_get_dns_records"
   return 0
 }
 
 _pleskxml_add_txt_record() {
 
-  _DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
+  _pleskxml_DBG 2 "Entered Plesk _pleskxml_add_txt_record($*)"
 
-  _DBG 2 'About to make API request (add TXT record)'
+  _pleskxml_DBG 2 'About to make API request (add TXT record)'
 
   _pleskxml_api_request "$_pleskxml_tplt_add_txt_record" "$1" "$2" "$3"
   _pleskxml_retcode=$?
@@ -739,7 +739,7 @@ _pleskxml_add_txt_record() {
   # $2 is the "host" entry within the domain, to add this to (eg '_acme_challenge')
   # $3 is the TXT record value
 
-  _DBG 2 'Returned from API request, now back in add_txt_record()'
+  _pleskxml_DBG 2 'Returned from API request, now back in add_txt_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -764,24 +764,24 @@ _pleskxml_add_txt_record() {
     | sed -E "s/^<result><id>([0-9]+)<\/id><\/result>$/\1/"
   )"
 
-  _DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_add_txt_record'
+  _pleskxml_DBG_VARDUMP 2
 
   return 0
 }
 
 _pleskxml_rmv_dns_record() {
 
-  _DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
+  _pleskxml_DBG 2 "Entered Plesk _pleskxml_rmv_dns_record($*)"
 
-  _DBG 2 'About to make API request (rmv TXT record)'
+  _pleskxml_DBG 2 'About to make API request (rmv TXT record)'
 
   _pleskxml_api_request "$_pleskxml_tplt_rmv_dns_record" "$1"
   _pleskxml_retcode=$?
 
   # $1 is the Plesk internal domain ID for the TXT record
 
-  _DBG 2 'Returned from API request, now back in rmv_dns_record()'
+  _pleskxml_DBG 2 'Returned from API request, now back in rmv_dns_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -791,8 +791,8 @@ _pleskxml_rmv_dns_record() {
 
   # OK, we should have removed a TXT record. If it failed, there wouldn't have been a "status:ok" above
 
-  _DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_dns_record'
+  _pleskxml_DBG_VARDUMP 2
 
   return 0
 }
@@ -802,13 +802,13 @@ _pleskxml_rmv_dns_record() {
 # 3rd arg = value of TXT record string to be found and removed
 _pleskxml_rmv_txt_record() {
 
-  _DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
+  _pleskxml_DBG 2 "Entered Plesk _pleskxml_rmv_dns_TXT_record($*). Getting DNS TXT records for the domain ID"
 
   _pleskxml_get_dns_records "$1" 'TXT'
   _pleskxml_retcode=$?
   # $1 is the Plesk internal domain ID for the domain
 
-  _DBG 2 'Returned from API request, now back in rmv_txt_record()'
+  _pleskxml_DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -820,7 +820,7 @@ _pleskxml_rmv_txt_record() {
   # Now we need to find our desired record in it (if it exists).
   # and might as well collapse any successful matches to a single line for line-count purposes at the same time
 
-  _DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
+  _pleskxml_DBG 2 "Filters to apply (as literal strings):${_pleskxml_newline}'<host>${2:-<NON_MATCHING_GARBAGE>}.'${_pleskxml_newline}'<value>${3:-<NON_MATCHING_GARBAGE>}</value>' "
 
   _pleskxml_result="$(printf '%s' "$_pleskxml_result" \
     | grep -F "<host>${2:-<NON_MATCHING_GARBAGE>}." \
@@ -832,7 +832,7 @@ _pleskxml_rmv_txt_record() {
   # ands this avoids regex and escaping which is easier
   # NOTE: the returned "host" field is actually the FQDN, not just the host ID, hence the grep match on that field.
 
-  _DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
+  _pleskxml_DBG 2 "Filtered result:${_pleskxml_newline}'$_pleskxml_result' "
 
   if printf '%s' "$_pleskxml_result" | grep -qiE "<result>.*<result>"; then
     # Error - contains <result>...</result>...<result>. Abort
@@ -844,7 +844,7 @@ _pleskxml_rmv_txt_record() {
   if printf '%s\n' "$_pleskxml_result" | grep -qiv "<result>"; then
     # No matching TXT records, so we're done.
     _info "Couldn't find a TXT record matching the requested host/value. Not an error, but a concern..."
-    _DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
+    _pleskxml_DBG 2 "Exiting Plesk _pleskxml_rmv_txt_record (without raising an error), as nothing more to do: the record requested for deletion doesn't exist"
     _pleskxml_result=''
     return 0
   fi
@@ -855,12 +855,12 @@ _pleskxml_rmv_txt_record() {
     | sed -E 's/^.*<id>([0-9]+)<\/id>.*$/\1/'
   )"
 
-  _DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
+  _pleskxml_DBG 2 "A unique matching DNS TXT record was found, with Plesk record ID = '$_pleskxml_result'. Calling API to delete this record."
 
   _pleskxml_rmv_dns_record "$_pleskxml_result"
   _pleskxml_retcode=$?
 
-  _DBG 2 'Returned from API request, now back in rmv_txt_record()'
+  _pleskxml_DBG 2 'Returned from API request, now back in rmv_txt_record()'
 
   if [ $_pleskxml_retcode -ne 0 ] || [ "$_pleskxml_errors" != '' ] || [ "$_pleskxml_result" = '' ]; then
     # Really, just testing return code should be enough, based on above code, but let's go "all-in" and test all variables returned
@@ -868,8 +868,8 @@ _pleskxml_rmv_txt_record() {
     return 1
   fi
 
-  _DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
-  _DBG_VARDUMP 2
+  _pleskxml_DBG 2 'SUCCESSFULLY exiting Plesk _pleskxml_rmv_txt_record'
+  _pleskxml_DBG_VARDUMP 2
 
   return 0
 }
@@ -892,72 +892,72 @@ if false; then
 
   _info 'Checking debug mode...'
 
-  _DBG_EARLY_CHECK_MODE
+  _pleskxml_DBG_EARLY_CHECK_MODE
 
-  _DBG 3 'Debug mode done. Now testing _pleskxml_get_variables()'
+  _pleskxml_DBG 3 'Debug mode done. Now testing _pleskxml_get_variables()'
 
   _pleskxml_get_variables
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '==============================================================='
+  _pleskxml_DBG 3 '==============================================================='
 
-  _DBG 3 'Testing _pleskxml_get_domain_ID()'
+  _pleskxml_DBG 3 'Testing _pleskxml_get_domain_ID()'
   _pleskxml_get_domain_ID "atticflat.uk"
 
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '==============================================================='
+  _pleskxml_DBG 3 '==============================================================='
 
   test_string="TEST STRING ADDED @ $(date)"
 
-  _DBG 3 "Testing add a TXT string: '$test_string' "
+  _pleskxml_DBG 3 "Testing add a TXT string: '$test_string' "
   _pleskxml_add_txt_record 874 '_test_subdomain' "$test_string"
 
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '==============================================================='
+  _pleskxml_DBG 3 '==============================================================='
 
-  _DBG 3 'Testing get DNS records (ALL)'
+  _pleskxml_DBG 3 'Testing get DNS records (ALL)'
   _pleskxml_get_dns_records 874
 
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '==============================================================='
+  _pleskxml_DBG 3 '==============================================================='
 
-  _DBG 3 'Testing get DNS records (TXT ONLY)'
+  _pleskxml_DBG 3 'Testing get DNS records (TXT ONLY)'
   _pleskxml_get_dns_records 874 TXT
 
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '==============================================================='
+  _pleskxml_DBG 3 '==============================================================='
 
-  _DBG 3 'Testing rmv a TXT string'
+  _pleskxml_DBG 3 'Testing rmv a TXT string'
   _pleskxml_rmv_txt_record 874 '_test_subdomain' "$test_string"
 
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '==============================================================='
+  _pleskxml_DBG 3 '==============================================================='
 
-  _DBG 3 'Re-testing get DNS records (TXT ONLY) after TXT string removal'
+  _pleskxml_DBG 3 'Re-testing get DNS records (TXT ONLY) after TXT string removal'
   _pleskxml_get_dns_records 874 TXT
 
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '==============================================================='
+  _pleskxml_DBG 3 '==============================================================='
 
-  _DBG 3 'Testing rmv a TXT string, with a non-matching string'
+  _pleskxml_DBG 3 'Testing rmv a TXT string, with a non-matching string'
   _pleskxml_rmv_txt_record 874 '_test_subdomain' 'JUNKegqw4bw4bb2'
 
-  _DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
-  _DBG_VARDUMP 3
+  _pleskxml_DBG 3 "$(printf 'RESULT:\n  _pleskxml_errors: "%s"\n  _pleskxml_retcode: "%s"\n  _pleskxml_result: "%s"\n\n' "$_pleskxml_errors" "$_pleskxml_retcode" "$_pleskxml_result")"
+  _pleskxml_DBG_VARDUMP 3
 
-  _DBG 3 '=============================================================== END OF RUN'
+  _pleskxml_DBG 3 '=============================================================== END OF RUN'
 
 fi


### PR DESCRIPTION
This DNS01 method allows acme.sh to set DNS TXT records using the Plesk XML API described at:
    https://docs.plesk.com/en-US/12.5/api-rpc/about-xml-api.28709
and more specifically: 
    https://docs.plesk.com/en-US/12.5/api-rpc/reference.28784

This may be needed if the DNS provider doesn't make the standard Plesk API available to a user - in which case, Plesk can't be configured using usual means or RFC1236. But the XML API is often still left accessible, and is well documented, so it can be used instead, for acme.sh purposes.


Note that I have tested the API calls work as expected, and is sanely structured, but I'm not an experienced shell coder. So I expect any number of stylistic and other amendments/corrections. It also includes a ton of debug code which won't hurt to leave in while checking.

Please help me to knock this module into shape for merging, and be gentle with me on it - I'm sure it needs a lot of attention! If edits are obvious, feel free to edit without asking if quicker.

Thanks :)

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->