### PR TITLE
createDomainKey: fix exitcode for creating new key

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1327,6 +1327,7 @@ createDomainKey() {
     if _createkey "$_cdl" "$CERT_KEY_PATH"; then
       _savedomainconf Le_Keylength "$_cdl"
       _info "The domain key is here: $(__green $CERT_KEY_PATH)"
+      return 0
     fi
   else
     if [ "$IS_RENEW" ]; then


### PR DESCRIPTION
when running acme.sh headless (without terminal) to create a new key
createDomainKey returns a non-zero exit-code.
explicitly returning zero avoids this.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->