### PR TITLE
Skip aliases of already verified domains

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2925,6 +2925,7 @@ _clearupdns() {
     _debug txt "$txt"
     if [ "$keyauthorization" = "$STATE_VERIFIED" ]; then
       _debug "$d is already verified, skip $vtype."
+      _alias_index="$(_math "$_alias_index" + 1)"
       continue
     fi
 
@@ -3775,6 +3776,7 @@ $_authorizations_map"
       _debug d "$d"
       if [ "$keyauthorization" = "$STATE_VERIFIED" ]; then
         _debug "$d is already verified, skip $vtype."
+        _alias_index="$(_math "$_alias_index" + 1)"
         continue
       fi
 


### PR DESCRIPTION
When issuing a two-domain certificate using a different alias for each domain, if the first domain is already verified, verification for the second domain is attempted (unsuccessfully) using the alias of the first domain.

For example, with the following CNAMES set up:

- _acme-challenge.aliastest1.example.com -> _acme-challenge.aliastest1.example.net
- _acme-challenge.aliastest2.example.com -> _acme-challenge.aliastest2.example.net

First, get a certificate issued for just aliastest1.example.com by running:

```
acme.sh --issue --staging \
  --domain aliastest1.example.com \
  --challenge-alias aliastest1.example.net \
  --dns dns_cf --debug
```

Now request a certificate that includes aliastest2.example.com as well:

```
acme.sh --issue --staging \
  --domain aliastest1.example.com \
  --challenge-alias aliastest1.example.net \
  --domain aliastest2.example.com \
  --challenge-alias aliastest2.example.net \
  --dns dns_cf --debug
```

The aliastest1.example.com domain is already verified so is skipped. Verification for the aliastest2.example.com domain fails because the TXT record is added to _acme-challenge.aliastest1.example.net instead of _acme-challenge.aliastest2.example.net: 

> [Thu Oct 18 16:53:21 DST 2018] d='aliastest1.example.com'
> [Thu Oct 18 16:53:21 DST 2018] aliastest1.example.com is already verified, skip dns-01.
> [Thu Oct 18 16:53:21 DST 2018] d='aliastest2.example.com'
> [Thu Oct 18 16:53:21 DST 2018] _d_alias='aliastest1.example.net'
> [Thu Oct 18 16:53:21 DST 2018] txtdomain='_acme-challenge.aliastest1.example.net'
> [Thu Oct 18 16:53:54 DST 2018] Verifying:aliastest2.example.com
> [Thu Oct 18 16:53:54 DST 2018] d='aliastest2.example.com'
> [Thu Oct 18 16:53:58 DST 2018] aliastest2.example.com:Verify error:DNS problem: NXDOMAIN looking up TXT for _acme-challenge.aliastest2.example.com

This pull request changes the `issue` and `_clearupdns` functions so that the alias index is incremented when skipping an already verified domain. This ensures that the correct alias will be used for subsequent domains:

> [Thu Oct 18 17:03:44 DST 2018] d='aliastest1.example.com'
> [Thu Oct 18 17:03:44 DST 2018] aliastest1.example.com is already verified, skip dns-01.
> [Thu Oct 18 17:03:44 DST 2018] d='aliastest2.example.com'
> [Thu Oct 18 17:03:44 DST 2018] _d_alias='aliastest2.example.com'
> [Thu Oct 18 17:03:44 DST 2018] txtdomain='_acme-challenge.aliastest2.example.net
> [Thu Oct 18 17:04:17 DST 2018] Verifying:aliastest2.example.com
> [Thu Oct 18 17:04:17 DST 2018] d='aliastest2.example.com'
> [Thu Oct 18 17:04:21 DST 2018] Success