### PR TITLE
Fix for VSCALE example

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -454,7 +454,7 @@ The `Infoblox_Creds` and `Infoblox_Server` will be saved in `~/.acme.sh/account.
 First you need to create/obtain API tokens on your [settings panel](https://vscale.io/panel/settings/tokens/).
 
 ```
-VSCALE_API_KEY="sdfsdfsdfljlbjkljlkjsdfoiwje"
+export VSCALE_API_KEY="sdfsdfsdfljlbjkljlkjsdfoiwje"
 ```
 
 Ok, let's issue a cert now:


### PR DESCRIPTION
Added "export" before VSCALE_API_KEY string in example.