### PR TITLE
Fix Vscale hostedzone

### DIFF
--- a/dnsapi/dns_vscale.sh
+++ b/dnsapi/dns_vscale.sh
@@ -102,7 +102,7 @@ _get_root() {
         return 1
       fi
 
-      hostedzone="$(echo "$response" | _egrep_o "{.*\"name\":\s*\"$h\".*}")"
+      hostedzone="$(echo "$response" | tr "{" "\n" | _egrep_o "\"name\":\s*\"$h\".*}")"
       if [ "$hostedzone" ]; then
         _domain_id=$(printf "%s\n" "$hostedzone" | _egrep_o "\"id\":\s*[0-9]+" | _head_n 1 | cut -d : -f 2 | tr -d \ )
         if [ "$_domain_id" ]; then


### PR DESCRIPTION
In case of >1 domains `"{.*\"name\":\s*\"$h\".*}")"` matches `{id: 1, name: a}, {id: 2, name: $h}` that leads to wrong `id` (we look for id=2, but match id=1)

`{[^{]*\"name\":\s*\"$h\"[^}]*}` matches just `{id: 2, name: $h}`