### PR TITLE
Allow dyn standard dns and debug nsupdate

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -146,13 +146,17 @@ Finally, make the DNS server and update Key available to `acme.sh`
 export NSUPDATE_SERVER="dns.example.com"
 export NSUPDATE_KEY="/path/to/your/nsupdate.key"
 ```
+and optionally (depending on DNS server)
+```
+export NSUPDATE_ZONE="example.com"
+```
 
 Ok, let's issue a cert now:
 ```
 acme.sh --issue --dns dns_nsupdate -d example.com -d www.example.com
 ```
 
-The `NSUPDATE_SERVER` and `NSUPDATE_KEY` settings will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+The `NSUPDATE_SERVER`, `NSUPDATE_KEY`, and `NSUPDATE_ZONE` settings will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
 
 ## 8. Use LuaDNS domain API

--- a/dnsapi/dns_nsupdate.sh
+++ b/dnsapi/dns_nsupdate.sh
@@ -13,14 +13,24 @@ dns_nsupdate_add() {
   _saveaccountconf NSUPDATE_SERVER "${NSUPDATE_SERVER}"
   _saveaccountconf NSUPDATE_SERVER_PORT "${NSUPDATE_SERVER_PORT}"
   _saveaccountconf NSUPDATE_KEY "${NSUPDATE_KEY}"
+  _saveaccountconf NSUPDATE_ZONE "${NSUPDATE_ZONE}"
   _info "adding ${fulldomain}. 60 in txt \"${txtvalue}\""
   [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_1" ] && nsdebug="-d"
   [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_2" ] && nsdebug="-D"
-  nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
+  if [ -z "${NSUPDATE_ZONE}" ]; then
+    nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
 server ${NSUPDATE_SERVER}  ${NSUPDATE_SERVER_PORT} 
 update add ${fulldomain}. 60 in txt "${txtvalue}"
 send
 EOF
+  else
+    nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
+server ${NSUPDATE_SERVER}  ${NSUPDATE_SERVER_PORT}
+zone ${NSUPDATE_ZONE}.
+update add ${fulldomain}. 60 in txt "${txtvalue}"
+send
+EOF
+  fi
   if [ $? -ne 0 ]; then
     _err "error updating domain"
     return 1
@@ -38,11 +48,20 @@ dns_nsupdate_rm() {
   _info "removing ${fulldomain}. txt"
   [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_1" ] && nsdebug="-d"
   [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_2" ] && nsdebug="-D"
-  nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
+  if [ -z "${NSUPDATE_ZONE}" ]; then
+    nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
 server ${NSUPDATE_SERVER}  ${NSUPDATE_SERVER_PORT} 
 update delete ${fulldomain}. txt
 send
 EOF
+  else
+    nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
+server ${NSUPDATE_SERVER}  ${NSUPDATE_SERVER_PORT}
+zone ${NSUPDATE_ZONE}.
+update delete ${fulldomain}. txt
+send
+EOF
+  fi
   if [ $? -ne 0 ]; then
     _err "error updating domain"
     return 1

--- a/dnsapi/dns_nsupdate.sh
+++ b/dnsapi/dns_nsupdate.sh
@@ -14,7 +14,9 @@ dns_nsupdate_add() {
   _saveaccountconf NSUPDATE_SERVER_PORT "${NSUPDATE_SERVER_PORT}"
   _saveaccountconf NSUPDATE_KEY "${NSUPDATE_KEY}"
   _info "adding ${fulldomain}. 60 in txt \"${txtvalue}\""
-  nsupdate -k "${NSUPDATE_KEY}" <<EOF
+  [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_1" ] && nsdebug="-d"
+  [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_2" ] && nsdebug="-D"
+  nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
 server ${NSUPDATE_SERVER}  ${NSUPDATE_SERVER_PORT} 
 update add ${fulldomain}. 60 in txt "${txtvalue}"
 send
@@ -34,7 +36,9 @@ dns_nsupdate_rm() {
   [ -n "${NSUPDATE_SERVER}" ] || NSUPDATE_SERVER="localhost"
   [ -n "${NSUPDATE_SERVER_PORT}" ] || NSUPDATE_SERVER_PORT=53
   _info "removing ${fulldomain}. txt"
-  nsupdate -k "${NSUPDATE_KEY}" <<EOF
+  [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_1" ] && nsdebug="-d"
+  [ -n "$DEBUG" ] && [ "$DEBUG" -ge "$DEBUG_LEVEL_2" ] && nsdebug="-D"
+  nsupdate -k "${NSUPDATE_KEY}" $nsdebug <<EOF
 server ${NSUPDATE_SERVER}  ${NSUPDATE_SERVER_PORT} 
 update delete ${fulldomain}. txt
 send


### PR DESCRIPTION
    dnsapi: Add option to set zone for nsupdate
    
    Some DNS servers for which dns_nsupdate.sh is applicable (such
    as dyn.com's 'Standard DNS' TSIG update mechanism), require that
    the zone be set during the nsupdate transaction.  Therefore we
    add a new environment variable NSUPDATE_ZONE which is used to
    set the zone for the DNS TSIG transaction.

   Also, add debugging options to nsupdate when --debug is used on acme.sh
   command line.
    
    Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>
