### PR TITLE
Bugfix for allowing '+' character in CloudFlare email

### DIFF
--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -34,7 +34,7 @@ dns_cf_add() {
   _saveaccountconf_mutable CF_Key "$CF_Key"
   _saveaccountconf_mutable CF_Email "$CF_Email"
 
-  _DOMAIN_CF_ZONES_CACHE_NAME_="$(echo "${CF_Email}_CF_ZONES_" | tr '@.' '__')"
+  _DOMAIN_CF_ZONES_CACHE_NAME_="$(echo "${CF_Email}_CF_ZONES_" | tr '+@.' '___')"
   _cleardomainconf "$_DOMAIN_CF_ZONES_CACHE_NAME_"
 
   _debug "First detect the root zone"
@@ -105,7 +105,7 @@ dns_cf_rm() {
     return 1
   fi
 
-  _DOMAIN_CF_ZONES_CACHE_NAME_="$(echo "${CF_Email}_CF_ZONES_" | tr '@.' '__')"
+  _DOMAIN_CF_ZONES_CACHE_NAME_="$(echo "${CF_Email}_CF_ZONES_" | tr '+@.' '___')"
 
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then


### PR DESCRIPTION
Using email address with an '+' currently makes the dns_cf.sh script unable to detect the root zone.

Error is:
[Thu Dec 27 15:02:44 CET 2018] First detect the root zone
[Thu Dec 27 15:02:44 CET 2018] _cf_zones='+emailpart2_xxx_xxx_CF_ZONES_'
[Thu Dec 27 15:02:44 CET 2018] emailpart1+emailpart2_xxx_xxx_CF_ZONES_ found
[Thu Dec 27 15:02:44 CET 2018] h='xxx.xxx.xxx.xxx'
[Thu Dec 27 15:02:44 CET 2018] h='xxx.xxx.xxx'
[Thu Dec 27 15:02:44 CET 2018] h='xxx.xxx'
[Thu Dec 27 15:02:44 CET 2018] h='xxx'
[Thu Dec 27 15:02:44 CET 2018] h
[Thu Dec 27 15:02:44 CET 2018] invalid domain
[Thu Dec 27 15:02:44 CET 2018] Error removing txt for domain:_acme-challenge.xxx.xxx.xxx.xxx