### PR TITLE
Added fixes so BuyPass Go ACME server can be used

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -13,8 +13,6 @@ _SCRIPT_="$0"
 
 _SUB_FOLDERS="dnsapi deploy"
 
-BUYPASS_CA="https://api.buypass.no/acme/directory"
-
 LETSENCRYPT_CA_V1="https://acme-v01.api.letsencrypt.org/directory"
 LETSENCRYPT_STAGING_CA_V1="https://acme-staging.api.letsencrypt.org/directory"
 


### PR DESCRIPTION
Had to add a few tweaks to be able to use the ACME server for BuyPass GO, as it seems to not quite conform to the ACME v1 specs implemented currently in acme.sh.

Resources:
https://api.buypass.com/acme/directory
https://www.buypass.com/ssl/resources/go-ssl-technical-specification

The tweaks should not affect existing functionality, and I've done some basic testing on CentOS.