### PR TITLE
Fix for removing TXT record from CloudFlare

### DIFF
--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -166,7 +166,7 @@ _get_root() {
     _savedomainconf "$_DOMAIN_CF_ZONES_CACHE_NAME_" "$(echo "$_cf_zones" | _base64)"
   else
     _debug "$_DOMAIN_CF_ZONES_CACHE_NAME_ found"
-    _cf_zones="$(echo "$_cf_zones" | _dbase64)"
+    _cf_zones="$(echo "$_cf_zones" | _dbase64 "multiline")"
   fi
 
   domain=$1


### PR DESCRIPTION
The current usage of "_dbase64" seems to crop the decoded output of the stored _cf_zones value. Which means the script fails to find the domain for removing the TXT record.

This shows like this when I added an extra debug output of the decoded string:
```
[Fri Dec 28 08:51:30 CET 2018] _cf_zones='ead","#worker:edit","#worker:read","#zone:edit","#zone:read","#zone_settings:edit","#zone_settings:read"],"plan":{"id":"0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee","name":"Free Website","price":0,"currency":"USD","frequency":"","is_subscribed":true,"can_subscribe":false,"legacy_id":"free","legacy_discount":false,"externally_managed":false}}],"result_info":{"page":1,"per_page":20,"total_pages":1,"count":5,"total_count":5},"success":true,"errors":[],"messages":[]}'
```
Changing the _dbase64 to use multiline solves it. I also reproduced this by using openssl manually on a CentOS 7.