### PR TITLE
Rackspace Cloud DNS dnsapi #1297 Duplicate and Revise

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ You don't have to do anything manually!
 1. hosting.de (https://www.hosting.de)
 1. Neodigit.net API (https://www.neodigit.net)
 1. Exoscale.com API (https://www.exoscale.com/)
+1. Rackspace Cloud DNS (https://www.rackspace.com)
 
 And:
 

--- a/dnsapi/dns_rackspace.sh
+++ b/dnsapi/dns_rackspace.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env sh
+#
+#
+#RACKSPACE_Username=""
+#
+#RACKSPACE_Apikey=""
+
+RACKSPACE_Endpoint="https://dns.api.rackspacecloud.com/v1.0"
+
+# 20190101 - Duplicating file for new pull request to dev branch
+# Original - tcocca:rackspace_dnsapi https://github.com/Neilpang/acme.sh/pull/1297
+
+########  Public functions #####################
+#Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_rackspace_add() {
+  fulldomain="$1"
+  _debug fulldomain="$fulldomain"
+  txtvalue="$2"
+  _debug txtvalue="$txtvalue"
+
+  _rackspace_check_auth || return 1
+  _rackspace_check_rootzone || return 1
+
+  _info "Creating TXT record."
+  if ! _rackspace_rest POST "$RACKSPACE_Tenant/domains/$_domain_id/records" "{\"records\":[{\"name\":\"$fulldomain\",\"type\":\"TXT\",\"data\":\"$txtvalue\",\"ttl\":300}]}"; then
+    return 1
+  fi
+  _debug2 response "$response"
+
+  if ! _contains "$response" "$txtvalue" >/dev/null; then
+    _err "Could not add TXT record."
+    return 1
+  fi
+
+  return 0
+}
+#fulldomain txtvalue
+dns_rackspace_rm() {
+  fulldomain=$1
+  _debug fulldomain="$fulldomain"
+  txtvalue=$2
+  _debug txtvalue="$txtvalue"
+
+  _rackspace_check_auth || return 1
+  _rackspace_check_rootzone || return 1
+
+  _info "Checking for TXT record."
+  if ! _get_recordid "$_domain_id" "$fulldomain" "$txtvalue"; then
+    _err "Could not get TXT record id."
+    return 1
+  fi
+
+  if [ "$_dns_record_id" = "" ]; then
+    _err "TXT record not found."
+    return 1
+  fi
+
+  _info "Removing TXT record."
+  if ! _delete_txt_record "$_domain_id" "$_dns_record_id"; then
+    _err "Could not remove TXT record $_dns_record_id."
+  fi
+
+  return 0
+}
+
+####################  Private functions below ##################################
+#_acme-challenge.www.domain.com
+#returns
+# _sub_domain=_acme-challenge.www
+# _domain=domain.com
+# _domain_id=sdjkglgdfewsdfg
+_get_root_zone() {
+  domain="$1"
+  i=2
+  p=1
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
+    _debug h "$h"
+    if [ -z "$h" ]; then
+      #not valid
+      return 1
+    fi
+
+    if ! _rackspace_rest GET "$RACKSPACE_Tenant/domains"; then
+      return 1
+    fi
+    _debug2 response "$response"
+
+    if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
+      _domain_id=$(echo "$response" | sed -n "s/^.*\"name\":\"$h\",\"id\":\([^,]*\),.*/\1/p")
+      if [ -n "$_domain_id" ]; then
+        _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
+        _domain=$h
+        return 0
+      fi
+      return 1
+    fi
+    p=$i
+    i=$(_math "$i" + 1)
+  done
+  return 1
+}
+_get_recordid() {
+  domainid="$1"
+  fulldomain="$2"
+  txtvalue="$3"
+
+  if ! _rackspace_rest GET "$RACKSPACE_Tenant/domains/$domainid/records?name=$fulldomain&type=TXT"; then
+    return 1
+  fi
+  _debug response "$response"
+
+  if ! _contains "$response" "$txtvalue"; then
+    _dns_record_id=0
+    return 0
+  fi
+
+  _dns_record_id=$(echo "$response" | tr '{' "\n" | grep "\"data\":\"$txtvalue\"" | sed -n 's/^.*"id":"\([^"]*\)".*/\1/p')
+  _debug _dns_record_id "$_dns_record_id"
+  return 0
+}
+_delete_txt_record() {
+  domainid="$1"
+  _dns_record_id="$2"
+
+  if ! _rackspace_rest DELETE "$RACKSPACE_Tenant/domains/$domainid/records?id=$_dns_record_id"; then
+    return 1
+  fi
+  _debug response "$response"
+
+  if ! _contains "$response" "RUNNING"; then
+    return 1
+  fi
+
+  return 0
+}
+_rackspace_rest() {
+  m="$1"
+  ep="$2"
+  data="$3"
+  _debug ep "$ep"
+
+  export _H1="Accept: application/json"
+  export _H2="X-Auth-Token: $RACKSPACE_Token"
+  export _H3="X-Project-Id: $RACKSPACE_Tenant"
+  export _H4="Content-Type: application/json"
+
+  if [ "$m" != "GET" ]; then
+    _debug data "$data"
+    response="$(_post "$data" "$RACKSPACE_Endpoint/$ep" "" "$m")"
+    retcode=$?
+  else
+    _info "Getting $RACKSPACE_Endpoint/$ep"
+    response="$(_get "$RACKSPACE_Endpoint/$ep")"
+    retcode=$?
+  fi
+
+  if [ "$retcode" != "0" ]; then
+    _err "error $ep"
+    return 1
+  fi
+  _debug2 response "$response"
+  return 0
+}
+_rackspace_authorization() {
+  export _H1="Content-Type: application/json"
+  data="{\"auth\":{\"RAX-KSKEY:apiKeyCredentials\":{\"username\":\"$RACKSPACE_Username\",\"apiKey\":\"$RACKSPACE_Apikey\"}}}"
+  _debug data "$data"
+  response="$(_post "$data" "https://identity.api.rackspacecloud.com/v2.0/tokens" "" "POST")"
+  retcode=$?
+  _debug2 response "$response"
+  if [ "$retcode" != "0" ]; then
+    _err "Authentication failed."
+    return 1
+  fi
+  if _contains "$response" "token"; then
+    RACKSPACE_Token="$(echo "$response" | _normalizeJson | sed -n 's/^.*"token":{.*,"id":"\([^"]*\)",".*/\1/p')"
+    RACKSPACE_Tenant="$(echo "$response" | _normalizeJson | sed -n 's/^.*"token":{.*,"id":"\([^"]*\)"}.*/\1/p')"
+    _debug RACKSPACE_Token "$RACKSPACE_Token"
+    _debug RACKSPACE_Tenant "$RACKSPACE_Tenant"
+  fi
+  return 0
+}
+_rackspace_check_auth() {
+  # retrieve the rackspace creds
+  RACKSPACE_Username="${RACKSPACE_Username:-$(_readaccountconf_mutable RACKSPACE_Username)}"
+  RACKSPACE_Apikey="${RACKSPACE_Apikey:-$(_readaccountconf_mutable RACKSPACE_Apikey)}"
+  
+  # check their vals for null
+  if [ -z "$RACKSPACE_Username" ] || [ -z "$RACKSPACE_Apikey" ]; then
+    RACKSPACE_Username=""
+    RACKSPACE_Apikey=""
+    _err "You didn't specify a Rackspace username and api key."
+    _err "Please set those values and try again."
+    return 1
+  fi
+
+  # save the username and api key to the account conf file.
+  _saveaccountconf_mutable RACKSPACE_Username "$RACKSPACE_Username"
+  _saveaccountconf_mutable RACKSPACE_Apikey "$RACKSPACE_Apikey"
+  
+  if [ -z "$RACKSPACE_Token" ]; then
+    _info "Getting authorization token."
+    if ! _rackspace_authorization; then
+      _err "Can not get token."
+    fi
+  fi
+}
+_rackspace_check_rootzone() {
+  _debug "First detect the root zone"
+  if ! _get_root_zone "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+  _debug _domain_id "$_domain_id"
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
+}

--- a/dnsapi/dns_rackspace.sh
+++ b/dnsapi/dns_rackspace.sh
@@ -17,21 +17,17 @@ dns_rackspace_add() {
   _debug fulldomain="$fulldomain"
   txtvalue="$2"
   _debug txtvalue="$txtvalue"
-
   _rackspace_check_auth || return 1
   _rackspace_check_rootzone || return 1
-
   _info "Creating TXT record."
   if ! _rackspace_rest POST "$RACKSPACE_Tenant/domains/$_domain_id/records" "{\"records\":[{\"name\":\"$fulldomain\",\"type\":\"TXT\",\"data\":\"$txtvalue\",\"ttl\":300}]}"; then
     return 1
   fi
   _debug2 response "$response"
-
   if ! _contains "$response" "$txtvalue" >/dev/null; then
     _err "Could not add TXT record."
     return 1
   fi
-
   return 0
 }
 #fulldomain txtvalue
@@ -40,26 +36,21 @@ dns_rackspace_rm() {
   _debug fulldomain="$fulldomain"
   txtvalue=$2
   _debug txtvalue="$txtvalue"
-
   _rackspace_check_auth || return 1
   _rackspace_check_rootzone || return 1
-
   _info "Checking for TXT record."
   if ! _get_recordid "$_domain_id" "$fulldomain" "$txtvalue"; then
     _err "Could not get TXT record id."
     return 1
   fi
-
   if [ "$_dns_record_id" = "" ]; then
     _err "TXT record not found."
     return 1
   fi
-
   _info "Removing TXT record."
   if ! _delete_txt_record "$_domain_id" "$_dns_record_id"; then
     _err "Could not remove TXT record $_dns_record_id."
   fi
-
   return 0
 }
 
@@ -80,12 +71,10 @@ _get_root_zone() {
       #not valid
       return 1
     fi
-
     if ! _rackspace_rest GET "$RACKSPACE_Tenant/domains"; then
       return 1
     fi
     _debug2 response "$response"
-
     if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
       _domain_id=$(echo "$response" | sed -n "s/^.*\"name\":\"$h\",\"id\":\([^,]*\),.*/\1/p")
       if [ -n "$_domain_id" ]; then
@@ -104,17 +93,14 @@ _get_recordid() {
   domainid="$1"
   fulldomain="$2"
   txtvalue="$3"
-
   if ! _rackspace_rest GET "$RACKSPACE_Tenant/domains/$domainid/records?name=$fulldomain&type=TXT"; then
     return 1
   fi
   _debug response "$response"
-
   if ! _contains "$response" "$txtvalue"; then
     _dns_record_id=0
     return 0
   fi
-
   _dns_record_id=$(echo "$response" | tr '{' "\n" | grep "\"data\":\"$txtvalue\"" | sed -n 's/^.*"id":"\([^"]*\)".*/\1/p')
   _debug _dns_record_id "$_dns_record_id"
   return 0
@@ -122,16 +108,13 @@ _get_recordid() {
 _delete_txt_record() {
   domainid="$1"
   _dns_record_id="$2"
-
   if ! _rackspace_rest DELETE "$RACKSPACE_Tenant/domains/$domainid/records?id=$_dns_record_id"; then
     return 1
   fi
   _debug response "$response"
-
   if ! _contains "$response" "RUNNING"; then
     return 1
   fi
-
   return 0
 }
 _rackspace_rest() {
@@ -139,12 +122,10 @@ _rackspace_rest() {
   ep="$2"
   data="$3"
   _debug ep "$ep"
-
   export _H1="Accept: application/json"
   export _H2="X-Auth-Token: $RACKSPACE_Token"
   export _H3="X-Project-Id: $RACKSPACE_Tenant"
   export _H4="Content-Type: application/json"
-
   if [ "$m" != "GET" ]; then
     _debug data "$data"
     response="$(_post "$data" "$RACKSPACE_Endpoint/$ep" "" "$m")"
@@ -185,7 +166,6 @@ _rackspace_check_auth() {
   # retrieve the rackspace creds
   RACKSPACE_Username="${RACKSPACE_Username:-$(_readaccountconf_mutable RACKSPACE_Username)}"
   RACKSPACE_Apikey="${RACKSPACE_Apikey:-$(_readaccountconf_mutable RACKSPACE_Apikey)}"
-  
   # check their vals for null
   if [ -z "$RACKSPACE_Username" ] || [ -z "$RACKSPACE_Apikey" ]; then
     RACKSPACE_Username=""
@@ -194,11 +174,9 @@ _rackspace_check_auth() {
     _err "Please set those values and try again."
     return 1
   fi
-
   # save the username and api key to the account conf file.
   _saveaccountconf_mutable RACKSPACE_Username "$RACKSPACE_Username"
   _saveaccountconf_mutable RACKSPACE_Apikey "$RACKSPACE_Apikey"
-  
   if [ -z "$RACKSPACE_Token" ]; then
     _info "Getting authorization token."
     if ! _rackspace_authorization; then


### PR DESCRIPTION
This commit is based on the original pull request #1297 by @tcocca for Rackspace Cloud DNS API plugin. The request seems to have been abandoned in an unfinished state so I have worked on the script provided script to complete it.

The script has been revised to pass the ShellCheck along with some minor refactoring.

I have tested it to issue plain, SAN, and wildcard certs. For example issuing a wildcard cert:

```
[tophr@ucdata-prd-01-iad ~]$ export RACKSPACE_Username="[REDACTED]"
[tophr@ucdata-prd-01-iad ~]$ export RACKSPACE_Apikey="[REDACTED]"
[tophr@ucdata-prd-01-iad ~]$ acme.sh --issue --dnssleep 30 --dns dns_rackspace  -d '*.unic.[REDACTED]'
[Wed Jan  2 02:47:45 CST 2019] Single domain='*.unic.[REDACTED]'
[Wed Jan  2 02:47:45 CST 2019] Getting domain auth token for each domain
[Wed Jan  2 02:47:46 CST 2019] Getting webroot for domain='*.unic.[REDACTED]'
[Wed Jan  2 02:47:46 CST 2019] Found domain api file: /root/.acme.sh/dnsapi/dns_rackspace.sh
[Wed Jan  2 02:47:46 CST 2019] Getting authorization token.
[Wed Jan  2 02:47:46 CST 2019] Getting https://dns.api.rackspacecloud.com/v1.0/[REDACTED]/domains
[Wed Jan  2 02:47:47 CST 2019] Getting https://dns.api.rackspacecloud.com/v1.0/[REDACTED]/domains
[Wed Jan  2 02:47:48 CST 2019] Creating TXT record.
[Wed Jan  2 02:47:48 CST 2019] Sleep 30 seconds for the txt records to take effect
[Wed Jan  2 02:48:18 CST 2019] Verifying:*.unic.[REDACTED]
[Wed Jan  2 02:48:21 CST 2019] Pending
[Wed Jan  2 02:48:23 CST 2019] Success
[Wed Jan  2 02:48:23 CST 2019] Removing DNS records.
[Wed Jan  2 02:48:23 CST 2019] Getting authorization token.
[Wed Jan  2 02:48:24 CST 2019] Getting https://dns.api.rackspacecloud.com/v1.0/[REDACTED]/domains
[Wed Jan  2 02:48:24 CST 2019] Getting https://dns.api.rackspacecloud.com/v1.0/[REDACTED]/domains
[Wed Jan  2 02:48:25 CST 2019] Checking for TXT record.
[Wed Jan  2 02:48:25 CST 2019] Getting https://dns.api.rackspacecloud.com/v1.0/[REDACTED]/domains/[REDACTED]/records?name=_acme-challenge.unic.[REDACTED]&type=TXT
[Wed Jan  2 02:48:25 CST 2019] Removing TXT record.
[Wed Jan  2 02:48:26 CST 2019] Verify finished, start to sign.
[Wed Jan  2 02:48:28 CST 2019] Cert success.
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
[Wed Jan  2 02:48:28 CST 2019] Your cert is in  /root/.acme.sh/cert/*.unic.[REDACTED]/*.unic.[REDACTED].cer 
[Wed Jan  2 02:48:28 CST 2019] Your cert key is in  /root/.acme.sh/cert/*.unic.[REDACTED]/*.unic.[REDACTED].key 
[Wed Jan  2 02:48:28 CST 2019] The intermediate CA cert is in  /root/.acme.sh/cert/*.unic.[REDACTED]/ca.cer 
[Wed Jan  2 02:48:28 CST 2019] And the full chain certs is there:  /root/.acme.sh/cert/*.unic.[REDACTED]/fullchain.cer 
```

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->