### PR TITLE
Check for DNS records to apply, if not then sleep

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3882,6 +3882,17 @@ $_authorizations_map"
 
     _info "Sleep $(__green $Le_DNSSleep) seconds for the txt records to take effect"
     _sleep "$Le_DNSSleep"
+
+    while true; do
+      doesTxtExist=$(dig @$(dig @8.8.8.8 $_main_domain ns +short | head -n1) TXT $txtdomain | grep "$txt")
+      if [ -z "$doesTxtExist" ]; then
+        _info "DNS TXT record has not been applied yet, sleep $(__green 3) seconds for the txt records to take effect"
+        _sleep "3"
+      else
+        _info "DNS records has been applied"
+        break
+      fi
+    done
   fi
 
   NGINX_RESTORE_VLIST=""


### PR DESCRIPTION
Hi @Neilpang 

This commit adds another check before failing hard:

[Sun Jan 20 00:30:38 CET 2019] Sleep 30 seconds for the txt records to take effect
[Sun Jan 20 00:31:09 CET 2019] Verifying:DOMAIN.TLD
[Sun Jan 20 00:31:12 CET 2019] DOMAIN.TLD:Verify error:DNS problem: NXDOMAIN looking up TXT for _acme-challenge.DOMAIN.TLD
[Sun Jan 20 00:31:12 CET 2019] Removing DNS records.
[Sun Jan 20 00:31:13 CET 2019] Don't need to remove.
[Sun Jan 20 00:31:13 CET 2019] Please add '--debug' or '--log' to check more details.
[Sun Jan 20 00:31:13 CET 2019] See: https://github.com/Neilpang/acme.sh/wiki/How-to-debug-acme.sh

What it does is run a dig lookup on the domain, if the DNS record still has not been applied, it will sleep for 3 more seconds. It runs two dig commands, the first one gets the nameserver for the domain and the second one gets the TXT record. Using the nameserver prevents caching the result.

This helps on two problems:

1. You can lower the DNS sleep time
2. Getting SSL certificate does not fail hard