### PR TITLE
Added dns_doapi.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ You don't have to do anything manually!
 1. Exoscale.com API (https://www.exoscale.com/)
 1. PointDNS API (https://pointhq.com/)
 1. Active24.cz API (https://www.active24.cz/)
+1. do.de API (https://www.do.de/)
 
 And:
 

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -1139,6 +1139,22 @@ You can then issue certs by using:
 ```acme.sh --issue --dns dns_pointhq -d example.com -d www.example.com
 ```
 
+## 59. Use do.de API
+
+Create an API token in your do.de account.
+
+Set your API token:
+```
+export DO_LETOKEN='FmD408PdqT1E269gUK57'
+```
+
+To issue a certificate run:
+```
+acme.sh --issue --dns dns_doapi -d example.com -d *.example.com
+```
+
+The API token will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+
 # Use custom API
 
 If your API is not supported yet, you can write your own DNS API.

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -1139,23 +1139,7 @@ You can then issue certs by using:
 ```acme.sh --issue --dns dns_pointhq -d example.com -d www.example.com
 ```
 
-## 59. Use do.de API
-
-Create an API token in your do.de account.
-
-Set your API token:
-```
-export DO_LETOKEN='FmD408PdqT1E269gUK57'
-```
-
-To issue a certificate run:
-```
-acme.sh --issue --dns dns_doapi -d example.com -d *.example.com
-```
-
-The API token will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
-
-## 60. Use Active24 API
+## 59. Use Active24 API
 
 Create an API token in the Active24 account section, documentation on https://faq.active24.com/cz/790131-REST-API-rozhran%C3%AD.
 
@@ -1171,6 +1155,22 @@ acme.sh --issue --dns dns_active24 -d example.com -d www.example.com --dnssleep 
 ```
 
 The `ACTIVE24_Token` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+
+## 60. Use do.de API
+
+Create an API token in your do.de account.
+
+Set your API token:
+```
+export DO_LETOKEN='FmD408PdqT1E269gUK57'
+```
+
+To issue a certificate run:
+```
+acme.sh --issue --dns dns_doapi -d example.com -d *.example.com
+```
+
+The API token will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
 # Use custom API
 

--- a/dnsapi/dns_doapi.sh
+++ b/dnsapi/dns_doapi.sh
@@ -24,7 +24,7 @@ dns_doapi_add() {
     _err "Please set DO_LETOKEN and try again."
     return 1
   fi
-  _saveaccountconf_mutable DO_LETOKEN  "$DO_LETOKEN"
+  _saveaccountconf_mutable DO_LETOKEN "$DO_LETOKEN"
 
   _info "Adding TXT record to ${fulldomain}"
   response="$(_get "$DO_API?token=$DO_LETOKEN&domain=${fulldomain}&value=${txtvalue}")"
@@ -46,7 +46,7 @@ dns_doapi_rm() {
     _err "Please set DO_LETOKEN and try again."
     return 1
   fi
-  _saveaccountconf_mutable DO_LETOKEN  "$DO_LETOKEN"
+  _saveaccountconf_mutable DO_LETOKEN "$DO_LETOKEN"
 
   _info "Deleting resource record $fulldomain"
   response="$(_get "$DO_API?token=$DO_LETOKEN&domain=${fulldomain}&action=delete")"

--- a/dnsapi/dns_doapi.sh
+++ b/dnsapi/dns_doapi.sh
@@ -26,13 +26,13 @@ dns_doapi_add() {
   fi
   _saveaccountconf_mutable DO_LETOKEN  "$DO_LETOKEN"
 
-  _info "Adding TXT record to ${_domain} as ${fulldomain}"
+  _info "Adding TXT record to ${fulldomain}"
   response="$(_get "$DO_API?token=$DO_LETOKEN&domain=${fulldomain}&value=${txtvalue}")"
   if _contains "${response}" 'success'; then
     return 0
   fi
   _err "Could not create resource record, check logs"
-  _err $response
+  _err "${response}"
   return 1
 }
 
@@ -54,6 +54,6 @@ dns_doapi_rm() {
     return 0
   fi
   _err "Could not delete resource record, check logs"
-  _err $response
+  _err "${response}"
   return 1
 }

--- a/dnsapi/dns_doapi.sh
+++ b/dnsapi/dns_doapi.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+
+# Official Let's Encrypt API for do.de / Domain-Offensive
+# 
+# This is different from the dns_do adapter, because dns_do is only usable for enterprise customers
+# This API is also available to private customers/individuals
+# 
+# Provide the required LetsEncrypt token like this: 
+# DO_LETOKEN="FmD408PdqT1E269gUK57"
+
+DO_API="https://www.do.de/api/letsencrypt"
+
+########  Public functions #####################
+
+#Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_doapi_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  DO_LETOKEN="${DO_LETOKEN:-$(_readaccountconf_mutable DO_LETOKEN)}"
+  if [ -z "$DO_LETOKEN" ]; then
+    DO_LETOKEN=""
+    _err "You didn't configure a do.de API token yet."
+    _err "Please set DO_LETOKEN and try again."
+    return 1
+  fi
+  _saveaccountconf_mutable DO_LETOKEN  "$DO_LETOKEN"
+
+  _info "Adding TXT record to ${_domain} as ${fulldomain}"
+  response="$(_get "$DO_API?token=$DO_LETOKEN&domain=${fulldomain}&value=${txtvalue}")"
+  if _contains "${response}" 'success'; then
+    return 0
+  fi
+  _err "Could not create resource record, check logs"
+  _err $response
+  return 1
+}
+
+dns_doapi_rm() {
+  fulldomain=$1
+
+  DO_LETOKEN="${DO_LETOKEN:-$(_readaccountconf_mutable DO_LETOKEN)}"
+  if [ -z "$DO_LETOKEN" ]; then
+    DO_LETOKEN=""
+    _err "You didn't configure a do.de API token yet."
+    _err "Please set DO_LETOKEN and try again."
+    return 1
+  fi
+  _saveaccountconf_mutable DO_LETOKEN  "$DO_LETOKEN"
+
+  _info "Deleting resource record $fulldomain"
+  response="$(_get "$DO_API?token=$DO_LETOKEN&domain=${fulldomain}&action=delete")"
+  if _contains "${response}" 'success'; then
+    return 0
+  fi
+  _err "Could not delete resource record, check logs"
+  _err $response
+  return 1
+}


### PR DESCRIPTION
Hi,

this new adapter adds support for the official LE API for the domain hosting company do.de. 
There is already support in acme.sh in the dns_do.sh adapter, but this API has some downsides: 
- it's only available to business/enterprise customers
- it requires you to save the full admin credentials (username/pw) in the server config of each machine
- old API uses SOAP/XML and is marked for deprecation

The new API is explicitly meant to set _acme-challenge records and provides authentication via a token mechanism. 
If you want to test this API, I will gladly send you a (test) token. Just tell me a mail address to send it to. 

The plugin was written according to the dev guidelines and also supports wildcard certifiates.

PS: I'm not 100% sure about the naming, but I didn't want to break compatibilty with the existing API. Suggestions for a different filename are welcome. 

Thanks,
Tobias