### PR TITLE
Add dns_maradns.sh

### DIFF
--- a/dnsapi/dns_maradns.sh
+++ b/dnsapi/dns_maradns.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+dns_maradns_add() {
+	_checkZoneFile || return 1
+	fulldomain="$1"
+	txtvalue="$2"
+	printf "%s. TXT '%s' ~\n" "$fulldomain" "$txtvalue" | tee -a "$MARA_ZONE_FILE" || return 1
+	_try_reload_maradns
+}
+
+dns_maradns_rm() {
+	_checkZoneFile || return 1
+	fulldomain="$1"
+	txtvalue="$2"
+	sed -i "/^$fulldomain.\+TXT '$txtvalue' ~/d" "$MARA_ZONE_FILE"
+	_try_reload_maradns
+}
+
+_checkZoneFile() {
+	if [ -w "$MARA_ZONE_FILE" ]; then
+		return 0
+	fi
+	_err "MARA_ZONE_FILE not set or not writable"
+	return 1
+}
+
+_try_reload_maradns() {
+	if [ -n "$MARA_DUENDE_PID" ]; then
+		kill -s HUP -- "$MARA_DUENDE_PID"
+		return $?
+	fi
+	if [ -r "$MARA_DUENDE_PID_PATH" ]; then
+		kill -s HUP -- "$(cat $MARA_DUENDE_PID_PATH)"
+		return $?
+	fi
+	_info "Reload MaraDNS manually (or provide MARA_DUENDE_PID or MARA_DUENDE_PID_PATH)"
+}


### PR DESCRIPTION
MaraDNS is a lightweight self-hosting DNS server. This patch adds
support for adding records to zone files stored on the server in the
format expected by MaraDNS. Path to the file should be exported in
MARA_ZONE_FILE environment variable. To reload the configuration
automatically, the user must provide pid of duende (the daemonization
tool that ships with MaraDNS) in MARA_DUENDE_PID or path to the pid file
(--pid argument to duende) in MARA_DUENDE_PID_PATH.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->