### PR TITLE
Add support for Thermo, Nexcess, and Futurehosting DNS APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Just set string "apache" as the second argument and it will force use of apache 
 acme.sh --issue --apache -d example.com -d www.example.com -d cp.example.com
 ```
 
-**This apache mode is only to issue the cert, it will not change your apache config files. 
+**This apache mode is only to issue the cert, it will not change your apache config files.
 You will need to configure your website config files to use the cert by yourself.
 We don't want to mess your apache server, don't worry.**
 
@@ -277,7 +277,7 @@ So, the config is not changed.
 acme.sh --issue --nginx -d example.com -d www.example.com -d cp.example.com
 ```
 
-**This nginx mode is only to issue the cert, it will not change your nginx config files. 
+**This nginx mode is only to issue the cert, it will not change your nginx config files.
 You will need to configure your website config files to use the cert by yourself.
 We don't want to mess your nginx server, don't worry.**
 
@@ -351,6 +351,9 @@ You don't have to do anything manually!
 1. PointDNS API (https://pointhq.com/)
 1. Active24.cz API (https://www.active24.cz/)
 1. do.de API (https://www.do.de/)
+1. Nexcess API (https://www.nexcess.net)
+1. Thermo.io API (https://www.thermo.io)
+1. Futurehosting API (https://www.futurehosting.com)
 
 And:
 
@@ -528,5 +531,5 @@ Please Star and Fork me.
 Your donation makes **acme.sh** better:
 
 1. PayPal/Alipay(支付宝)/Wechat(微信): [https://donate.acme.sh/](https://donate.acme.sh/)
-  
+
 [Donate List](https://github.com/Neilpang/acme.sh/wiki/Donate-list)

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -1,6 +1,6 @@
 # How to use DNS API
 
-If your dns provider doesn't provide api access, you can use our dns alias mode: 
+If your dns provider doesn't provide api access, you can use our dns alias mode:
 
 https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode
 
@@ -891,7 +891,7 @@ acme.sh --issue --dns dns_loopia -d example.com -d *.example.com
 The username and password will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 ## 45. Use ACME DNS API
 
-ACME DNS is a limited DNS server with RESTful HTTP API to handle ACME DNS challenges easily and securely. 
+ACME DNS is a limited DNS server with RESTful HTTP API to handle ACME DNS challenges easily and securely.
 https://github.com/joohoi/acme-dns
 
 ```
@@ -1011,7 +1011,6 @@ acme.sh --issue --dns dns_netcup -d example.com -d www.example.com
 ```
 
 The `NC_Apikey`,`NC_Apipw` and `NC_CID` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
-
 ## 52. Use GratisDNS.dk
 
 GratisDNS.dk (https://gratisdns.dk/) does not provide an API to update DNS records (other than IPv4 and IPv6
@@ -1171,6 +1170,63 @@ acme.sh --issue --dns dns_doapi -d example.com -d *.example.com
 ```
 
 The API token will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+
+## 61. Use Nexcess API
+
+First, you'll need to login to the [Nexcess.net Client Portal](https://portal.nexcess.net) and [generate a new API token](https://portal.nexcess.net/api-token).
+
+Once you have a token, set it in your systems environment:
+
+```
+export NW_API_TOKEN="YOUR_TOKEN_HERE"
+export NW_API_ENDPOINT="https://portal.nexcess.net"
+```
+
+Finally, we'll issue the certificate: (Nexcess DNS publishes at max every 15 minutes, we recommend setting a 900 second `--dnssleep`)
+
+```
+acme.sh --issue --dns dns_nw -d example.com --dnssleep 900
+```
+
+The `NW_API_TOKEN` and `NW_API_ENDPOINT` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+
+## 62. Use Thermo.io API
+
+First, you'll need to login to the [Thermo.io Client Portal](https://core.thermo.io) and [generate a new API token](https://core.thermo.io/api-token).
+
+Once you have a token, set it in your systems environment:
+
+```
+export NW_API_TOKEN="YOUR_TOKEN_HERE"
+export NW_API_ENDPOINT="https://core.thermo.io"
+```
+
+Finally, we'll issue the certificate: (Thermo DNS publishes at max every 15 minutes, we recommend setting a 900 second `--dnssleep`)
+
+```
+acme.sh --issue --dns dns_nw -d example.com --dnssleep 900
+```
+
+The `NW_API_TOKEN` and `NW_API_ENDPOINT` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+
+## 63. Use Futurehosting API
+
+First, you'll need to login to the [Futurehosting Client Portal](https://my.futurehosting.com) and [generate a new API token](https://my.futurehosting.com/api-token).
+
+Once you have a token, set it in your systems environment:
+
+```
+export NW_API_TOKEN="YOUR_TOKEN_HERE"
+export NW_API_ENDPOINT="https://my.futurehosting.com"
+```
+
+Finally, we'll issue the certificate: (Futurehosting DNS publishes at max every 15 minutes, we recommend setting a 900 second `--dnssleep`)
+
+```
+acme.sh --issue --dns dns_nw -d example.com --dnssleep 900
+```
+
+The `NW_API_TOKEN` and `NW_API_ENDPOINT` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
 # Use custom API
 

--- a/dnsapi/dns_nw.sh
+++ b/dnsapi/dns_nw.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env sh
+########################################################################
+# NocWorx script for acme.sh
+#
+# Handles DNS Updates for the Following vendors:
+#   - Nexcess.net
+#   - Thermo.io
+#   - Futurehosting.com
+#
+# Environment variables:
+#
+#  - NW_API_TOKEN  (Your API Token)
+#  - NW_API_ENDPOINT (One of the following listed below)
+#
+# Endpoints:
+#   - https://portal.nexcess.net (default)
+#   - https://core.thermo.io
+#   - https://my.futurehosting.com
+#
+#  Note: If you do not have an API token, one can be generated at one
+#        of the following URLs:
+#        - https://portal.nexcess.net/api-token
+#        - https://core.thermo.io/api-token
+#        - https://my.futurehosting.com/api-token
+#
+# Author: Frank Laszlo <flaszlo@nexcess.net>
+
+NW_API_VERSION="0"
+
+# dns_nw_add() - Add TXT record
+# Usage: dns_nw_add _acme-challenge.subdomain.domain.com "XyZ123..."
+dns_nw_add() {
+  host="${1}"
+  txtvalue="${2}"
+
+  _debug host "${host}"
+  _debug txtvalue "${txtvalue}"
+
+  if ! _check_nw_api_creds; then
+    return 1
+  fi
+
+  _info "Using NocWorx (${NW_API_ENDPOINT})"
+  _debug "Calling: dns_nw_add() '${host}' '${txtvalue}'"
+
+  _debug "Detecting root zone"
+  if ! _get_root "${host}"; then
+    _err "Zone for domain does not exist."
+    return 1
+  fi
+  _debug _zone_id "${_zone_id}"
+  _debug _sub_domain "${_sub_domain}"
+  _debug _domain "${_domain}"
+
+  _post_data="{\"zone_id\": \"${_zone_id}\", \"type\": \"TXT\", \"host\": \"${host}\", \"target\": \"${txtvalue}\", \"ttl\": \"300\"}"
+
+  if _rest POST "dns-record" "${_post_data}" && [ -n "${response}" ]; then
+    _record_id=$(printf "%s\n" "${response}" | _egrep_o "\"record_id\": *[0-9]+" | cut -d : -f 2 | tr -d " " | _head_n 1)
+    _debug _record_id "${_record_id}"
+
+    if [ -z "$_record_id" ]; then
+      _err "Error adding the TXT record."
+      return 1
+    fi
+
+    _info "TXT record successfully added."
+    return 0
+  fi
+
+  return 1
+}
+
+# dns_nw_rm() - Remove TXT record
+# Usage: dns_nw_rm _acme-challenge.subdomain.domain.com "XyZ123..."
+dns_nw_rm() {
+  host="${1}"
+  txtvalue="${2}"
+
+  _debug host "${host}"
+  _debug txtvalue "${txtvalue}"
+
+  if ! _check_nw_api_creds; then
+    return 1
+  fi
+
+  _info "Using NocWorx (${NW_API_ENDPOINT})"
+  _debug "Calling: dns_nw_rm() '${host}'"
+
+  _debug "Detecting root zone"
+  if ! _get_root "${host}"; then
+    _err "Zone for domain does not exist."
+    return 1
+  fi
+  _debug _zone_id "${_zone_id}"
+  _debug _sub_domain "${_sub_domain}"
+  _debug _domain "${_domain}"
+
+  _parameters="?zone_id=${_zone_id}"
+
+  if _rest GET "dns-record" "${_parameters}" && [ -n "${response}" ]; then
+    response="$(echo "${response}" | tr -d "\n" | sed 's/^\[\(.*\)\]$/\1/' | sed -e 's/{"record_id":/|"record_id":/g' | sed 's/|/&{/g' | tr "|" "\n")"
+    _debug response "${response}"
+
+    record="$(echo "${response}" | _egrep_o "{.*\"host\": *\"${_sub_domain}\", *\"target\": *\"${txtvalue}\".*}")"
+    _debug record "${record}"
+
+    if [ "${record}" ]; then
+      _record_id=$(printf "%s\n" "${record}" | _egrep_o "\"record_id\": *[0-9]+" | _head_n 1 | cut -d : -f 2 | tr -d \ )
+      if [ "${_record_id}" ]; then
+        _debug _record_id "${_record_id}"
+
+        _rest DELETE "dns-record/${_record_id}"
+
+        _info "TXT record successfully deleted."
+        return 0
+      fi
+
+      return 1
+    fi
+
+    return 0
+  fi
+
+  return 1
+}
+
+_check_nw_api_creds() {
+  NW_API_TOKEN="${NW_API_TOKEN:-$(_readaccountconf_mutable NW_API_TOKEN)}"
+  NW_API_ENDPOINT="${NW_API_ENDPOINT:-$(_readaccountconf_mutable NW_API_ENDPOINT)}"
+
+  if [ -z "${NW_API_ENDPOINT}" ]; then
+    NW_API_ENDPOINT="https://portal.nexcess.net"
+  fi
+
+  if [ -z "${NW_API_TOKEN}" ]; then
+    _err "You have not defined your NW_API_TOKEN."
+    _err "Please create your token and try again."
+    _err "If you need to generate a new token, please visit one of the following URLs:"
+    _err "  - https://portal.nexcess.net/api-token"
+    _err "  - https://core.thermo.io/api-token"
+    _err "  - https://my.futurehosting.com/api-token"
+
+    return 1
+  fi
+
+  _saveaccountconf_mutable NW_API_TOKEN "${NW_API_TOKEN}"
+  _saveaccountconf_mutable NW_API_ENDPOINT "${NW_API_ENDPOINT}"
+}
+
+_get_root() {
+  domain="${1}"
+  i=2
+  p=1
+
+  if _rest GET "dns-zone"; then
+    response="$(echo "${response}" | tr -d "\n" | sed 's/^\[\(.*\)\]$/\1/' | sed -e 's/{"zone_id":/|"zone_id":/g' | sed 's/|/&{/g' | tr "|" "\n")"
+
+    _debug response "${response}"
+    while true; do
+      h=$(printf "%s" "${domain}" | cut -d . -f $i-100)
+      _debug h "${h}"
+      if [ -z "${h}" ]; then
+        #not valid
+        return 1
+      fi
+
+      hostedzone="$(echo "${response}" | _egrep_o "{.*\"domain\": *\"${h}\".*}")"
+      if [ "${hostedzone}" ]; then
+        _zone_id=$(printf "%s\n" "${hostedzone}" | _egrep_o "\"zone_id\": *[0-9]+" | _head_n 1 | cut -d : -f 2 | tr -d \ )
+        if [ "${_zone_id}" ]; then
+          _sub_domain=$(printf "%s" "${domain}" | cut -d . -f 1-${p})
+          _domain="${h}"
+          return 0
+        fi
+        return 1
+      fi
+      p=$i
+      i=$(_math "${i}" + 1)
+    done
+  fi
+  return 1
+}
+
+_rest() {
+  method="${1}"
+  ep="/${2}"
+  data="${3}"
+
+  _debug method "${method}"
+  _debug ep "${ep}"
+
+  export _H1="Accept: application/json"
+  export _H2="Content-Type: application/json"
+  export _H3="Api-Version: ${NW_API_VERSION}"
+  export _H4="User-Agent: NW-ACME-CLIENT"
+  export _H5="Authorization: Bearer ${NW_API_TOKEN}"
+
+  if [ "${method}" != "GET" ]; then
+    _debug data "${data}"
+    response="$(_post "${data}" "${NW_API_ENDPOINT}${ep}" "" "${method}")"
+  else
+    response="$(_get "${NW_API_ENDPOINT}${ep}${data}")"
+  fi
+
+  if [ "${?}" != "0" ]; then
+    _err "error ${ep}"
+    return 1
+  fi
+  _debug2 response "${response}"
+  return 0
+}


### PR DESCRIPTION
This adds DNS support for [Nexcess](https://www.nexcess.net), [Futurehosting](https://www.futurehosting.com), and [Thermo.io](https://www.thermo.io)

All 3 use the same API backend (different endpoints).