### PR TITLE
Set NS1 DNS record TTL to 0

### DIFF
--- a/dnsapi/dns_nsone.sh
+++ b/dnsapi/dns_nsone.sh
@@ -46,7 +46,7 @@ dns_nsone_add() {
   if [ "$count" = "0" ]; then
     _info "Adding record"
 
-    if _nsone_rest PUT "zones/$_domain/$fulldomain/TXT" "{\"answers\":[{\"answer\":[\"$txtvalue\"]}],\"type\":\"TXT\",\"domain\":\"$fulldomain\",\"zone\":\"$_domain\"}"; then
+    if _nsone_rest PUT "zones/$_domain/$fulldomain/TXT" "{\"answers\":[{\"answer\":[\"$txtvalue\"]}],\"type\":\"TXT\",\"domain\":\"$fulldomain\",\"zone\":\"$_domain\",\"ttl\":0}"; then
       if _contains "$response" "$fulldomain"; then
         _info "Added"
         #todo: check if the record takes effect
@@ -62,7 +62,7 @@ dns_nsone_add() {
     prev_txt=$(printf "%s\n" "$response" | _egrep_o "\"domain\":\"$fulldomain\",\"short_answers\":\[\"[^,]*\]" | _head_n 1 | cut -d: -f3 | cut -d, -f1)
     _debug "prev_txt" "$prev_txt"
 
-    _nsone_rest POST "zones/$_domain/$fulldomain/TXT" "{\"answers\": [{\"answer\": [\"$txtvalue\"]},{\"answer\": $prev_txt}],\"type\": \"TXT\",\"domain\":\"$fulldomain\",\"zone\": \"$_domain\"}"
+    _nsone_rest POST "zones/$_domain/$fulldomain/TXT" "{\"answers\": [{\"answer\": [\"$txtvalue\"]},{\"answer\": $prev_txt}],\"type\": \"TXT\",\"domain\":\"$fulldomain\",\"zone\": \"$_domain\",\"ttl\":0}"
     if [ "$?" = "0" ] && _contains "$response" "$fulldomain"; then
       _info "Updated!"
       #todo: check if the record takes effect


### PR DESCRIPTION
Default TTL of a zone might be high, which is annoying when testing
with the ACME staging API or when quickly creating multiple certificates.
I think setting the TTL to 0 makes sense as acme.sh is the only one checking this,
so having an always up to date response seems desirable.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->