### PR TITLE
Update Dockerfile (apline 3.9 and tzdata)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.9
 
 RUN apk update -f \
   && apk --no-cache add -f \
@@ -7,6 +7,7 @@ RUN apk update -f \
   bind-tools \
   curl \
   socat \
+  tzdata \
   && rm -rf /var/cache/apk/*
 
 ENV LE_CONFIG_HOME /acme.sh


### PR DESCRIPTION
Update apline base image and tzdata was added to output time stamps of log messages in the same time zone as the hostsystem. (Conainer must be started with the environment variable TZ e.g. -TZ=Europe/Berlin).