### PR TITLE
Add online.net DNS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ You don't have to do anything manually!
 1. Thermo.io API (https://www.thermo.io)
 1. Futurehosting API (https://www.futurehosting.com)
 1. Rackspace Cloud DNS (https://www.rackspace.com)
+1. Online.net API (https://online.net/)
 
 And:
 

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -1243,6 +1243,23 @@ Now, let's issue a cert:
 acme.sh --issue --dns dns_rackspace -d example.com -d www.example.com
 ```
 
+## 65. Use Online API
+
+First, you'll need to retrive your API key, which is available under https://console.online.net/en/api/access
+
+```
+export ONLINE_API_KEY='xxx'
+```
+
+To issue a cert run:
+
+```
+acme.sh --issue --dns dns_online -d example.com -d www.example.com
+```
+
+`ONLINE_API_KEY` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+
+
 # Use custom API
 
 If your API is not supported yet, you can write your own DNS API.

--- a/dnsapi/dns_online.sh
+++ b/dnsapi/dns_online.sh
@@ -68,10 +68,10 @@ dns_online_rm() {
     return 1
   fi
   
-  rid=$(echo $response|_egrep_o "\"id\":[0-9]+,\"name\":\"$_sub_domain\",\"data\":\"\\\u0022$txtvalue\\\u0022\""|cut -d ':' -f 2|cut -d ',' -f 1)
+  rid=$(echo $response | _egrep_o "\"id\":[0-9]+,\"name\":\"$_sub_domain\",\"data\":\"\\\u0022$txtvalue\\\u0022\"" | cut -d ':' -f 2 | cut -d ',' -f 1)
   _debug rid "$rid"
   if [ -z "$rid" ]; then
-     return 1
+    return 1
   fi
 
   _info "Creating temporary zone version"
@@ -126,7 +126,7 @@ _get_root() {
     if ! _contains "$response" "Domain not found" >/dev/null; then
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
       _domain="$h"
-      _real_dns_version=$(echo "$response"|_egrep_o '"uuid_ref":.*'|cut -d ':' -f 2|cut -d '"' -f 2)
+      _real_dns_version=$(echo "$response" | _egrep_o '"uuid_ref":.*' | cut -d ':' -f 2 | cut -d '"' -f 2)
       return 0
     fi
     p=$i
@@ -141,11 +141,11 @@ _get_root() {
 _online_create_temporary_zone_version() {
   
   _online_rest POST "domain/$_domain/version" "name=acme.sh"
-  if [ "$?" != "0" ] ; then
+  if [ "$?" != "0" ]; then
     return 1
   fi 
 
-  _temporary_dns_version=$(echo "$response"|_egrep_o '"uuid_ref":.*'|cut -d ':' -f 2|cut -d '"' -f 2)
+  _temporary_dns_version=$(echo "$response" | _egrep_o '"uuid_ref":.*' | cut -d ':' -f 2 | cut -d '"' -f 2)
 
   # Creating a dummy record in this temporary version, because online.net doesn't accept enabling an empty version
   _online_create_TXT_record "$_temporary_dns_version" "dummy.acme.sh" "dummy"
@@ -157,17 +157,17 @@ _online_destroy_zone() {
   version_id=$1
   _online_rest DELETE "domain/$_domain/version/$version_id"
 
-  if [ "$?" != "0" ] ; then
+  if [ "$?" != "0" ]; then
     return 1
-  fi 
+  fi
   return 0
- }
+}
 
 _online_enable_zone() {
   version_id=$1
   _online_rest PATCH "domain/$_domain/version/$version_id/enable"
 
-  if [ "$?" != "0" ] ; then
+  if [ "$?" != "0" ]; then
     return 1
   fi 
   return 0
@@ -183,7 +183,7 @@ _online_create_TXT_record() {
   # Note : the normal, expected response SHOULD be "Unknown method".
   # this happens because the API HTTP response contains a Location: header, that redirect
   # to an unknown online.net endpoint.
-  if [ "$?" != "0" ] || _contains "$response" "Unknown method" ; then
+  if [ "$?" != "0" ] || _contains "$response" "Unknown method"; then
     return 0
   else
     _err "error $response"

--- a/dnsapi/dns_online.sh
+++ b/dnsapi/dns_online.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env sh
+
+# Online API
+# https://console.online.net/en/api/
+#
+# Requires Online API key set in ONLINE_API_KEY
+
+########  Public functions #####################
+
+ONLINE_API="https://api.online.net/api/v1"
+
+#Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_online_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  if ! _online_check_config; then
+    return 1
+  fi
+
+  _debug "First detect the root zone"
+  if ! _get_root "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
+  _debug _real_dns_version "$_real_dns_version"
+
+  _info "Creating temporary zone version"
+  _online_create_temporary_zone_version
+  _info "Enabling temporary zone version"
+  _online_enable_zone "$_temporary_dns_version"
+
+  _info "Adding record"
+  _online_create_TXT_record "$_real_dns_version" "$_sub_domain" "$txtvalue"
+  _info "Disabling temporary version"
+  _online_enable_zone "$_real_dns_version"
+  _info "Destroying temporary version"
+  _online_destroy_zone "$_temporary_dns_version"
+
+  _info "Record added."
+  return 0
+}
+
+#fulldomain
+dns_online_rm() {
+  fulldomain=$1
+  txtvalue=$2
+
+  if ! _online_check_config; then
+    return 1
+  fi
+
+  _debug "First detect the root zone"
+  if ! _get_root "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
+  _debug _real_dns_version "$_real_dns_version"
+
+  _debug "Getting txt records"
+  if ! _online_rest GET "domain/$_domain/version/active"; then
+    return 1
+  fi
+  
+  rid=$(echo $response|_egrep_o "\"id\":[0-9]+,\"name\":\"$_sub_domain\",\"data\":\"\\\u0022$txtvalue\\\u0022\""|cut -d ':' -f 2|cut -d ',' -f 1)
+  _debug rid "$rid"
+  if [ -z "$rid" ]; then
+     return 1
+  fi
+
+  _info "Creating temporary zone version"
+  _online_create_temporary_zone_version
+  _info "Enabling temporary zone version"
+  _online_enable_zone "$_temporary_dns_version"
+
+  _info "Removing DNS record"
+  _online_rest DELETE "domain/$_domain/version/$_real_dns_version/zone/$rid"
+  _info "Disabling temporary version"
+  _online_enable_zone "$_real_dns_version"
+  _info "Destroying temporary version"
+  _online_destroy_zone "$_temporary_dns_version"
+
+  return 0
+}
+
+####################  Private functions below ##################################
+
+_online_check_config() {
+
+  if [ -z "$ONLINE_API_KEY" ]; then
+    _err "No API key specified for Online API."
+    _err "Create your key and export it as ONLINE_API_KEY"
+    return 1
+  fi
+
+  _saveaccountconf ONLINE_API_KEY "$ONLINE_API_KEY"
+
+  return 0
+}
+
+#_acme-challenge.www.domain.com
+#returns
+# _sub_domain=_acme-challenge.www
+# _domain=domain.com
+_get_root() {
+  domain=$1
+  i=2
+  p=1
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
+    if [ -z "$h" ]; then
+      #not valid
+      return 1
+    fi
+    if ! _online_rest GET "domain/$h/version/active"; then
+      _err "Unable to retrive DNS zone matching this domain"
+      return 1
+    fi
+
+    if ! _contains "$response" "Domain not found" >/dev/null; then
+      _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
+      _domain="$h"
+      _real_dns_version=$(echo "$response"|_egrep_o '"uuid_ref":.*'|cut -d ':' -f 2|cut -d '"' -f 2)
+      return 0
+    fi
+    p=$i
+    i=$(_math "$i" + 1)
+  done
+  return 1
+}
+
+
+# this function create a temporary zone version
+# as online.net does not allow updating an active version
+_online_create_temporary_zone_version() {
+  
+  _online_rest POST "domain/$_domain/version" "name=acme.sh"
+  if [ "$?" != "0" ] ; then
+    return 1
+  fi 
+
+  _temporary_dns_version=$(echo "$response"|_egrep_o '"uuid_ref":.*'|cut -d ':' -f 2|cut -d '"' -f 2)
+
+  # Creating a dummy record in this temporary version, because online.net doesn't accept enabling an empty version
+  _online_create_TXT_record "$_temporary_dns_version" "dummy.acme.sh" "dummy"
+
+  return 0
+}
+
+_online_destroy_zone() {
+  version_id=$1
+  _online_rest DELETE "domain/$_domain/version/$version_id"
+
+  if [ "$?" != "0" ] ; then
+    return 1
+  fi 
+  return 0
+ }
+
+_online_enable_zone() {
+  version_id=$1
+  _online_rest PATCH "domain/$_domain/version/$version_id/enable"
+
+  if [ "$?" != "0" ] ; then
+    return 1
+  fi 
+  return 0
+}
+
+_online_create_TXT_record() {
+  version=$1
+  txt_name=$2
+  txt_value=$3
+
+  _online_rest POST "domain/$_domain/version/$version/zone" "type=TXT&name=$txt_name&data=%22$txt_value%22&ttl=60&priority=0"
+
+  # Note : the normal, expected response SHOULD be "Unknown method".
+  # this happens because the API HTTP response contains a Location: header, that redirect
+  # to an unknown online.net endpoint.
+  if [ "$?" != "0" ] || _contains "$response" "Unknown method" ; then
+    return 0
+  else
+    _err "error $response"
+    return 1
+  fi
+}
+
+_online_rest() {
+  m=$1
+  ep="$2"
+  data="$3"
+  _debug "$ep"
+  _online_url="$ONLINE_API/$ep"
+  _debug2 _online_url "$_online_url"
+  export _H1="Authorization: Bearer $ONLINE_API_KEY"
+  export _H2="X-Pretty-JSON: 1"
+  if [ "$data" ] || [ "$m" = "PATCH" ] || [ "$m" = "POST" ] || [ "$m" = "PUT" ] || [ "$m" = "DELETE" ]; then
+    _debug data "$data"
+    response="$(_post "$data" "$_online_url" "" "$m")"
+  else
+    response="$(_get "$_online_url")"
+  fi
+  if [ "$?" != "0" ] || _contains "$response" "invalid_grant" || _contains "$response" "Method not allowed"; then
+    _err "error $response"
+    return 1
+  fi
+  _debug2 response "$response"
+  return 0
+}

--- a/dnsapi/dns_online.sh
+++ b/dnsapi/dns_online.sh
@@ -138,7 +138,7 @@ _get_root() {
 # this function create a temporary zone version
 # as online.net does not allow updating an active version
 _online_create_temporary_zone_version() {
- 
+
   _online_rest POST "domain/$_domain/version" "name=acme.sh"
   if [ "$?" != "0" ]; then
     return 1

--- a/dnsapi/dns_online.sh
+++ b/dnsapi/dns_online.sh
@@ -67,8 +67,8 @@ dns_online_rm() {
   if ! _online_rest GET "domain/$_domain/version/active"; then
     return 1
   fi
-  
-  rid=$(echo $response | _egrep_o "\"id\":[0-9]+,\"name\":\"$_sub_domain\",\"data\":\"\\\u0022$txtvalue\\\u0022\"" | cut -d ':' -f 2 | cut -d ',' -f 1)
+
+  rid=$(echo "$response" | _egrep_o "\"id\":[0-9]+,\"name\":\"$_sub_domain\",\"data\":\"\\\u0022$txtvalue\\\u0022\"" | cut -d ':' -f 2 | cut -d ',' -f 1)
   _debug rid "$rid"
   if [ -z "$rid" ]; then
     return 1
@@ -135,15 +135,14 @@ _get_root() {
   return 1
 }
 
-
 # this function create a temporary zone version
 # as online.net does not allow updating an active version
 _online_create_temporary_zone_version() {
-  
+ 
   _online_rest POST "domain/$_domain/version" "name=acme.sh"
   if [ "$?" != "0" ]; then
     return 1
-  fi 
+  fi
 
   _temporary_dns_version=$(echo "$response" | _egrep_o '"uuid_ref":.*' | cut -d ':' -f 2 | cut -d '"' -f 2)
 
@@ -169,7 +168,7 @@ _online_enable_zone() {
 
   if [ "$?" != "0" ]; then
     return 1
-  fi 
+  fi
   return 0
 }
 


### PR DESCRIPTION
This adds support for the Online (https://online.net/) DNS API.

Related issue : #2093 