### PR TITLE
Populate $Le_Domain in _installcert() if empty

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4758,6 +4758,10 @@ _installcert() {
   _reload_cmd="$6"
   _backup_prefix="$7"
 
+  if [ "$Le_Domain" = "" ]; then
+    Le_Domain="$_main_domain"
+  fi
+
   if [ "$_real_cert" = "$NO_VALUE" ]; then
     _real_cert=""
   fi


### PR DESCRIPTION
This allows the reload command to use $Le_Domain when called during initial cert --issue

(This should resolve #2122)