### PR TITLE
fix deploy/qiniu.sh base64

### DIFF
--- a/deploy/qiniu.sh
+++ b/deploy/qiniu.sh
@@ -87,6 +87,6 @@ qiniu_deploy() {
 }
 
 _make_access_token() {
-  _token="$(printf "%s\n" "$1" | _hmac "sha1" "$(printf "%s" "$QINIU_SK" | _hex_dump | tr -d " ")" | _base64)"
+  _token="$(printf "%s\n" "$1" | _hmac "sha1" "$(printf "%s" "$QINIU_SK" | _hex_dump | tr -d " ")" | _base64 | tr -- '+/' '-_')"
   echo "$QINIU_AK:$_token"
 }


### PR DESCRIPTION
According to the doc (https://developer.qiniu.com/kodo/manual/1231/appendix#1), we should use URL-safe base64 instead of plain base64 for token calculation.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->