### PR TITLE
fix doc of qiniu deploy script

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -349,10 +349,10 @@ $ export QINIU_SK="bar"
 $ acme.sh --deploy -d example.com --deploy-hook qiniu
 ```
 
-假如您部署的证书为泛域名证书，您还需要设置 `QINIU_CDN_DOMAIN` 变量，指定实际需要部署的域名：
+假如您部署的证书为泛域名证书，您还需要设置 `QINIU_CDN_DOMAIN` 变量，指定实际需要部署的域名(请注意泛域名前的点)：
 
 ```sh
-$ export QINIU_CDN_DOMAIN="cdn.example.com"
+$ export QINIU_CDN_DOMAIN=".cdn.example.com"
 $ acme.sh --deploy -d example.com --deploy-hook qiniu
 ```
 
@@ -375,10 +375,10 @@ $ acme.sh --deploy -d example.com --deploy-hook qiniu
 
 (Optional), If you are using wildcard certificate,
 you may need export `QINIU_CDN_DOMAIN` to specify which domain
-you want to update:
+you want to update (please note the leading dot):
 
 ```sh
-$ export QINIU_CDN_DOMAIN="cdn.example.com"
+$ export QINIU_CDN_DOMAIN=".cdn.example.com"
 $ acme.sh --deploy -d example.com --deploy-hook qiniu
 ```
 


### PR DESCRIPTION
A leading dot should be included when updating wildcard domains on Qiniu CDN.

For example, to update a wildcard domain *.cdn.example.com, you should export `QINIU_CDN_DOMAIN=".cdn.example.com"`, instead of "cdn.example.com"

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->