### PR TITLE
Make the Loopia API endpoint configurable

### DIFF
--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -88,8 +88,8 @@ _loopia_load_config() {
     LOOPIA_User=""
     LOOPIA_Password=""
 
-    _err "You don't specify loopia user and password yet."
-    _err "Please create you key and try again."
+    _err "A valid Loopia API user and password not provided."
+    _err "Please provide a valid API user and try again."
 
     return 1
   fi

--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -18,9 +18,7 @@ dns_loopia_add() {
     return 1
   fi
 
-  #save the api key and email to the account conf file.
-  _saveaccountconf_mutable LOOPIA_User "$LOOPIA_User"
-  _saveaccountconf_mutable LOOPIA_Password "$LOOPIA_Password"
+  _loopia_save_config
 
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
@@ -45,9 +43,7 @@ dns_loopia_rm() {
     return 1
   fi
 
-  #save the api key and email to the account conf file.
-  _saveaccountconf_mutable LOOPIA_User "$LOOPIA_User"
-  _saveaccountconf_mutable LOOPIA_Password "$LOOPIA_Password"
+  _loopia_save_config
 
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
@@ -99,6 +95,11 @@ _loopia_load_config() {
   fi
 
   return 0
+}
+
+_loopia_save_config() {
+  _saveaccountconf_mutable LOOPIA_User "$LOOPIA_User"
+  _saveaccountconf_mutable LOOPIA_Password "$LOOPIA_Password"
 }
 
 _loopia_get_records() {

--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -4,8 +4,10 @@
 #LOOPIA_User="username"
 #
 #LOOPIA_Password="password"
+#
+#LOOPIA_Api="https://api.loopia.<TLD>/RPCSERV"
 
-LOOPIA_Api="https://api.loopia.se/RPCSERV"
+LOOPIA_Api_Default="https://api.loopia.se/RPCSERV"
 
 ########  Public functions #####################
 
@@ -81,8 +83,13 @@ dns_loopia_rm() {
 ####################  Private functions below ##################################
 
 _loopia_load_config() {
+  LOOPIA_Api="${LOOPIA_Api:-$(_readaccountconf_mutable LOOPIA_Api)}"
   LOOPIA_User="${LOOPIA_User:-$(_readaccountconf_mutable LOOPIA_User)}"
   LOOPIA_Password="${LOOPIA_Password:-$(_readaccountconf_mutable LOOPIA_Password)}"
+
+  if [ -z "$LOOPIA_Api" ]; then
+    LOOPIA_Api="$LOOPIA_Api_Default"
+  fi
 
   if [ -z "$LOOPIA_User" ] || [ -z "$LOOPIA_Password" ]; then
     LOOPIA_User=""
@@ -98,6 +105,9 @@ _loopia_load_config() {
 }
 
 _loopia_save_config() {
+  if [ "$LOOPIA_Api" != "$LOOPIA_Api_Default" ]; then
+    _saveaccountconf_mutable LOOPIA_Api "$LOOPIA_Api"
+  fi
   _saveaccountconf_mutable LOOPIA_User "$LOOPIA_User"
   _saveaccountconf_mutable LOOPIA_Password "$LOOPIA_Password"
 }

--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -70,7 +70,7 @@ dns_loopia_rm() {
         <value><string>%s</string></value>
       </param>
     </params>
-  </methodCall>' $LOOPIA_User $LOOPIA_Password "$_domain" "$_sub_domain")
+  </methodCall>' "$LOOPIA_User" "$LOOPIA_Password" "$_domain" "$_sub_domain")
 
   response="$(_post "$xml_content" "$LOOPIA_Api" "" "POST")"
 

--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -14,13 +14,7 @@ dns_loopia_add() {
   fulldomain=$1
   txtvalue=$2
 
-  LOOPIA_User="${LOOPIA_User:-$(_readaccountconf_mutable LOOPIA_User)}"
-  LOOPIA_Password="${LOOPIA_Password:-$(_readaccountconf_mutable LOOPIA_Password)}"
-  if [ -z "$LOOPIA_User" ] || [ -z "$LOOPIA_Password" ]; then
-    LOOPIA_User=""
-    LOOPIA_Password=""
-    _err "You don't specify loopia user and password yet."
-    _err "Please create you key and try again."
+  if ! _loopia_load_config; then
     return 1
   fi
 
@@ -47,13 +41,7 @@ dns_loopia_rm() {
   fulldomain=$1
   txtvalue=$2
 
-  LOOPIA_User="${LOOPIA_User:-$(_readaccountconf_mutable LOOPIA_User)}"
-  LOOPIA_Password="${LOOPIA_Password:-$(_readaccountconf_mutable LOOPIA_Password)}"
-  if [ -z "$LOOPIA_User" ] || [ -z "$LOOPIA_Password" ]; then
-    LOOPIA_User=""
-    LOOPIA_Password=""
-    _err "You don't specify LOOPIA user and password yet."
-    _err "Please create you key and try again."
+  if ! _loopia_load_config; then
     return 1
   fi
 
@@ -95,6 +83,23 @@ dns_loopia_rm() {
 }
 
 ####################  Private functions below ##################################
+
+_loopia_load_config() {
+  LOOPIA_User="${LOOPIA_User:-$(_readaccountconf_mutable LOOPIA_User)}"
+  LOOPIA_Password="${LOOPIA_Password:-$(_readaccountconf_mutable LOOPIA_Password)}"
+
+  if [ -z "$LOOPIA_User" ] || [ -z "$LOOPIA_Password" ]; then
+    LOOPIA_User=""
+    LOOPIA_Password=""
+
+    _err "You don't specify loopia user and password yet."
+    _err "Please create you key and try again."
+
+    return 1
+  fi
+
+  return 0
+}
 
 _loopia_get_records() {
   domain=$1


### PR DESCRIPTION
Loopia provides hosting in several countries. Each hosting location has it's own API endpoint, such as `https://api.loopia.<TLD>/RPCSERV`, where `<TLD>` is one of: com, no, rs, se.

The current `LOOPIA_Api` variable is hard-coded to `.se` TLD. This prevents using the Loopia DNS API on other hosting locations.

This PR makes the Loopia API endpoint configurable.

References:

 - https://www.loopia.com/api/authentication/
 - https://www.loopia.no/api/authentication/
 - https://www.loopia.rs/api/authentication/
 - https://www.loopia.se/api/authentication/