### PR TITLE
Fix gcloud most-specific zone match

### DIFF
--- a/dnsapi/dns_gcloud.sh
+++ b/dnsapi/dns_gcloud.sh
@@ -139,7 +139,7 @@ _dns_gcloud_find_zone() {
     --format="value(name, dnsName)" \
     --filter="$filter" \
     | while read -r dnsName name; do
-      printf "%s\t%s\t%s\n" "$(awk -F"." '{print NF-1}' <<< "$name")" "$dnsName" "$name"
+      printf "%s\t%s\t%s\n" "$(echo $name | awk -F"." '{print NF-1}')" "$dnsName" "$name"
     done \
     | sort -n -r | _head_n 1 | cut -f2,3 | grep '^.*'); then
     _err "_dns_gcloud_find_zone: Can't find a matching managed zone! Perhaps wrong project or gcloud credentials?"

--- a/dnsapi/dns_gcloud.sh
+++ b/dnsapi/dns_gcloud.sh
@@ -141,7 +141,7 @@ _dns_gcloud_find_zone() {
     | while read -r dnsName name; do
       printf "%s\t%s\t%s\n" "$(echo "$name" | awk -F"." '{print NF-1}')" "$dnsName" "$name"
     done \
-    | sort -n -r | _head_n 1 | cut -f2,3 | grep '^.*'); then
+      | sort -n -r | _head_n 1 | cut -f2,3 | grep '^.*'); then
     _err "_dns_gcloud_find_zone: Can't find a matching managed zone! Perhaps wrong project or gcloud credentials?"
     return 1
   fi

--- a/dnsapi/dns_gcloud.sh
+++ b/dnsapi/dns_gcloud.sh
@@ -139,7 +139,7 @@ _dns_gcloud_find_zone() {
     --format="value(name, dnsName)" \
     --filter="$filter" \
     | while read -r dnsName name; do
-      printf "%s\t%s\t%s\n" "$(echo $name | awk -F"." '{print NF-1}')" "$dnsName" "$name"
+      printf "%s\t%s\t%s\n" "$(echo "$name" | awk -F"." '{print NF-1}')" "$dnsName" "$name"
     done \
     | sort -n -r | _head_n 1 | cut -f2,3 | grep '^.*'); then
     _err "_dns_gcloud_find_zone: Can't find a matching managed zone! Perhaps wrong project or gcloud credentials?"

--- a/dnsapi/dns_gcloud.sh
+++ b/dnsapi/dns_gcloud.sh
@@ -134,12 +134,12 @@ _dns_gcloud_find_zone() {
   filter="$filter)"
   _debug filter "$filter"
 
-  # List domains and find the longest match (in case of some levels of delegation)
+  # List domains and find the zone with the deepest sub-domain (in case of some levels of delegation)
   if ! match=$(gcloud dns managed-zones list \
     --format="value(name, dnsName)" \
     --filter="$filter" \
     | while read -r dnsName name; do
-      printf "%s\t%s\t%s\n" "${#dnsName}" "$dnsName" "$name"
+      printf "%s\t%s\t%s\n" "$(awk -F"." '{print NF-1}' <<< "$name")" "$dnsName" "$name"
     done \
     | sort -n -r | _head_n 1 | cut -f2,3 | grep '^.*'); then
     _err "_dns_gcloud_find_zone: Can't find a matching managed zone! Perhaps wrong project or gcloud credentials?"


### PR DESCRIPTION
Most specific zone selected by deepest sub-domain (how many '.' in the domain)
rather than seemingly irrelevant count of the number of characters within the zone.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->