### PR TITLE
Add acmeproxy provider

### DIFF
--- a/dnsapi/dns_acmeproxy.sh
+++ b/dnsapi/dns_acmeproxy.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
 
-## API integration by Jason Keller and Elijah Tenai
+## Acmeproxy DNS provider to be used with acmeproxy (http://github.com/mdbraber/acmeproxy)
+## API integration by Maarten den Braber
 ##
-## Report any bugs via https://github.com/jasonkeller/acme.sh
+## Report any bugs via https://github.com/mdbraber/acme.sh
 
 dns_acmeproxy_add() {
   fulldomain="${1}"

--- a/dnsapi/dns_acmeproxy.sh
+++ b/dnsapi/dns_acmeproxy.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+
+## API integration by Jason Keller and Elijah Tenai
+##
+## Report any bugs via https://github.com/jasonkeller/acme.sh
+
+dns_acmeproxy_add() {
+  fulldomain="${1}"
+  txtvalue="${2}"
+  action="present"
+
+  _debug "Calling: _acmeproxy_request() '${fulldomain}' '${txtvalue}' '${action}'"
+  _acmeproxy_request $fulldomain $txtvalue $action
+}
+
+dns_acmeproxy_rm() {
+  fulldomain="${1}"
+  txtvalue="${2}"
+  action="cleanup"
+
+  _debug "Calling: _acmeproxy_request() '${fulldomain}' '${txtvalue}' '${action}'"
+  _acmeproxy_request $fulldomain $txtvalue $action
+}
+
+_acmeproxy_request() {
+
+  ## Nothing to see here, just some housekeeping
+  fulldomain=$1
+  txtvalue=$2
+  action=$3
+
+  _info "Using acmeproxy"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+
+  ACMEPROXY_ENDPOINT="${ACMEPROXY_ENDPOINT:-$(_readaccountconf_mutable ACMEPROXY_ENDPOINT)}"
+  ACMEPROXY_USERNAME="${ACMEPROXY_USERNAME:-$(_readaccountconf_mutable ACMEPROXY_USERNAME)}"
+  ACMEPROXY_PASSWORD="${ACMEPROXY_PASSWORD:-$(_readaccountconf_mutable ACMEPROXY_PASSWORD)}"
+
+  ## Check for the endpoint
+  if [ -z "ACMEPROXY_ENDPOINT" ]; then
+    ACMEPROXY_ENDPOINT=""
+    _err "You didn't specify the endpoint"
+    _err "Please set them via 'export ACMEPROXY_ENDPOINT=https://ip:port' and try again."
+    return 1
+  fi
+
+  ## Check for the credentials
+  if [ -z "$ACMEPROXY_USERNAME" ] || [ -z "$ACMEPROXY_PASSWORD" ]; then
+    ACMEPROXY_USERNAME=""
+    ACMEPROXY_PASSWORD=""
+    _err "You didn't set username and password"
+    _err "Please set them via 'export ACMEPROXY_USERNAME=...' and 'export ACMEPROXY_PASSWORD=...' and try again."
+    return 1
+  fi
+
+  ## Save the credentials to the account file
+  _saveaccountconf_mutable ACMEPROXY_ENDPOINT "$ACMEPROXY_ENDPOINT"
+  _saveaccountconf_mutable ACMEPROXY_USERNAME "$ACMEPROXY_USERNAME"
+  _saveaccountconf_mutable ACMEPROXY_PASSWORD "$ACMEPROXY_PASSWORD"
+
+  ## Base64 encode the credentials
+  credentials=$(printf "%b" "$ACMEPROXY_USERNAME:$ACMEPROXY_PASSWORD" | _base64)
+
+  ## Construct the HTTP Authorization header
+  export _H1="Authorization: Basic $credentials"
+  export _H2="Accept: application/json"
+  export _H3="Content-Type: application/json"
+
+  ## Add the challenge record to the acmeproxy grid member
+  response="$(_post "{\"fqdn\": \"$fulldomain.\", \"value\": \"$txtvalue\"}" "$ACMEPROXY_ENDPOINT/$action" "" "POST")"
+
+  ## Let's see if we get something intelligible back from the unit
+  if echo "$response" | grep "\"$txtvalue\"" > /dev/null; then
+    _info "Successfully created the txt record"
+    return 0
+  else
+    _err "Error encountered during record addition"
+    _err "$response"
+    return 1
+  fi
+
+}
+
+####################  Private functions below ##################################

--- a/dnsapi/dns_acmeproxy.sh
+++ b/dnsapi/dns_acmeproxy.sh
@@ -11,7 +11,7 @@ dns_acmeproxy_add() {
   action="present"
 
   _debug "Calling: _acmeproxy_request() '${fulldomain}' '${txtvalue}' '${action}'"
-  _acmeproxy_request $fulldomain $txtvalue $action
+  _acmeproxy_request "$fulldomain" "$txtvalue" "$action"
 }
 
 dns_acmeproxy_rm() {
@@ -20,7 +20,7 @@ dns_acmeproxy_rm() {
   action="cleanup"
 
   _debug "Calling: _acmeproxy_request() '${fulldomain}' '${txtvalue}' '${action}'"
-  _acmeproxy_request $fulldomain $txtvalue $action
+  _acmeproxy_request "$fulldomain" "$txtvalue" "$action"
 }
 
 _acmeproxy_request() {
@@ -39,7 +39,7 @@ _acmeproxy_request() {
   ACMEPROXY_PASSWORD="${ACMEPROXY_PASSWORD:-$(_readaccountconf_mutable ACMEPROXY_PASSWORD)}"
 
   ## Check for the endpoint
-  if [ -z "ACMEPROXY_ENDPOINT" ]; then
+  if [ -z "$ACMEPROXY_ENDPOINT" ]; then
     ACMEPROXY_ENDPOINT=""
     _err "You didn't specify the endpoint"
     _err "Please set them via 'export ACMEPROXY_ENDPOINT=https://ip:port' and try again."
@@ -72,7 +72,7 @@ _acmeproxy_request() {
   response="$(_post "{\"fqdn\": \"$fulldomain.\", \"value\": \"$txtvalue\"}" "$ACMEPROXY_ENDPOINT/$action" "" "POST")"
 
   ## Let's see if we get something intelligible back from the unit
-  if echo "$response" | grep "\"$txtvalue\"" > /dev/null; then
+  if echo "$response" | grep "\"$txtvalue\"" >/dev/null; then
     _info "Successfully updated the txt record"
     return 0
   else

--- a/dnsapi/dns_acmeproxy.sh
+++ b/dnsapi/dns_acmeproxy.sh
@@ -73,7 +73,7 @@ _acmeproxy_request() {
 
   ## Let's see if we get something intelligible back from the unit
   if echo "$response" | grep "\"$txtvalue\"" > /dev/null; then
-    _info "Successfully created the txt record"
+    _info "Successfully updated the txt record"
     return 0
   else
     _err "Error encountered during record addition"


### PR DESCRIPTION
This DNS providers can be used with the `acmeproxy` provider - see http://github.com/mdbraber/acmeproxy. The intended use is having a single host that holds DNS API credentials while other hosts can requests their (sub)domain requests through this host.