### PR TITLE
dns_acmeproxy: Username/password no longer required

### DIFF
--- a/dnsapi/dns_acmeproxy.sh
+++ b/dnsapi/dns_acmeproxy.sh
@@ -46,15 +46,6 @@ _acmeproxy_request() {
     return 1
   fi
 
-  ## Check for the credentials
-  if [ -z "$ACMEPROXY_USERNAME" ] || [ -z "$ACMEPROXY_PASSWORD" ]; then
-    ACMEPROXY_USERNAME=""
-    ACMEPROXY_PASSWORD=""
-    _err "You didn't set username and password"
-    _err "Please set them via 'export ACMEPROXY_USERNAME=...' and 'export ACMEPROXY_PASSWORD=...' and try again."
-    return 1
-  fi
-
   ## Save the credentials to the account file
   _saveaccountconf_mutable ACMEPROXY_ENDPOINT "$ACMEPROXY_ENDPOINT"
   _saveaccountconf_mutable ACMEPROXY_USERNAME "$ACMEPROXY_USERNAME"

--- a/dnsapi/dns_acmeproxy.sh
+++ b/dnsapi/dns_acmeproxy.sh
@@ -51,13 +51,19 @@ _acmeproxy_request() {
   _saveaccountconf_mutable ACMEPROXY_USERNAME "$ACMEPROXY_USERNAME"
   _saveaccountconf_mutable ACMEPROXY_PASSWORD "$ACMEPROXY_PASSWORD"
 
-  ## Base64 encode the credentials
-  credentials=$(printf "%b" "$ACMEPROXY_USERNAME:$ACMEPROXY_PASSWORD" | _base64)
+  if [ -z "$ACMEPROXY_USERNAME" ] || [ -z "$ACMEPROXY_PASSWORD" ]; then
+    _info "ACMEPROXY_USERNAME and/or ACMEPROXY_PASSWORD not set - using without client authentication! Make sure you're using server authentication (e.g. IP-based)"
+    export _H1="Accept: application/json"
+    export _H2="Content-Type: application/json"
+  else
+    ## Base64 encode the credentials
+    credentials=$(printf "%b" "$ACMEPROXY_USERNAME:$ACMEPROXY_PASSWORD" | _base64)
 
-  ## Construct the HTTP Authorization header
-  export _H1="Authorization: Basic $credentials"
-  export _H2="Accept: application/json"
-  export _H3="Content-Type: application/json"
+    ## Construct the HTTP Authorization header
+    export _H1="Authorization: Basic $credentials"
+    export _H2="Accept: application/json"
+    export _H3="Content-Type: application/json"
+  fi
 
   ## Add the challenge record to the acmeproxy grid member
   response="$(_post "{\"fqdn\": \"$fulldomain.\", \"value\": \"$txtvalue\"}" "$ACMEPROXY_ENDPOINT/$action" "" "POST")"


### PR DESCRIPTION
Due to a new version of `acmeproxy` that offers the option to use IP-based authentication on the server side, username and password are no longer required (but still possible) on the client side.