### PR TITLE
Challenge route is not a POST-as-GET, should have empty json object

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4289,7 +4289,7 @@ $_authorizations_map"
       sleep 2
       _debug "checking"
       if [ "$ACME_VERSION" = "2" ]; then
-        _send_signed_request "$uri"
+        _send_signed_request "$uri" "{}"
       else
         response="$(_get "$uri")"
       fi


### PR DESCRIPTION
To verify the validity of a challenge, there should be an empty body in the post request. The route for a challenge is not listed as a POST-as-GET route in the acme v2 specification.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->