### PR TITLE
Help text suggests bad practice.

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6108,7 +6108,7 @@ Parameters:
 
   --notify-level  0|1|2|3           Set the notification level:  Default value is $NOTIFY_LEVEL_DEFAULT.
                                      0: disabled, no notification will be sent. 
-                                     1: send notification only when there is an error. No news is good news.
+                                     1: send notification only when there is an error.
                                      2: send notification when a cert is successfully renewed, or there is an error
                                      3: send notification when a cert is skipped, renewdd, or error
   --notify-mode   0|1               Set notification mode. Default value is $NOTIFY_MODE_DEFAULT.


### PR DESCRIPTION
Please remove the phrase `No news is good news.` as it suggests to decide to go on with a bad operational habit.
 
Why I am stating this is because that `no news` also could mean that:
- your `cron` daemon stopped working,
- your MTA has issues (in case or mail notifications of course),
- anything in between the host running `acme.sh` and your client went wrong.
 
(... and probably you will not notice in time if `acme.sh` would otherwise send an error notification (if it runs anyway))
 
If you expect a daily mail (using `--notify-level 3`) you can always be sure that `acme.sh` has ran successfully before. You can also tick the `acme.sh` checkbox in the daily operational report of your enterprise. ;)
