### PR TITLE
Dev

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -31,9 +31,9 @@ dns_aws_add() {
   # it does not honour [sections] in the ini formatted credentials file.
   if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     CREDFILE="${HOME}/.aws/credentials"
-    if [ -e ${CREDFILE} ]; then
-      AWS_ACCESS_KEY_ID=$(grep -m 1 -i AWS_ACCESS_KEY_ID ${CREDFILE} | cut -f 2 -d"=" | tr -d ' ')
-      AWS_SECRET_ACCESS_KEY=$(grep -m 1 -i AWS_SECRET_ACCESS_KEY ${CREDFILE} | cut -f 2 -d"=" | tr -d ' ')
+    if [ -e "$CREDFILE" ]; then
+      AWS_ACCESS_KEY_ID=$(grep -m 1 -i AWS_ACCESS_KEY_ID "$CREDFILE" | cut -f 2 -d"=" | tr -d ' ')
+      AWS_SECRET_ACCESS_KEY=$(grep -m 1 -i AWS_SECRET_ACCESS_KEY "$CREDFILE" | cut -f 2 -d"=" | tr -d ' ')
     fi
     # todo: if the key is found in the creds file, then if we can assume it'll be there in the future,
     # then there's likely no point saving it in the account config, so we should do what needs to be done

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -26,6 +26,20 @@ dns_aws_add() {
     _use_container_role || _use_instance_role
   fi
 
+  # attempt to get AWS creds from a local creds file, if not already set.
+  # this is naive, it just grabs the first values from .aws/credentials
+  # it does not honour [sections] in the ini formatted credentials file.
+  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    CREDFILE="${HOME}/.aws/credentials"
+    if [ -e $CREDFILE ]; then
+      AWS_ACCESS_KEY_ID=$(grep -m 1 -i AWS_ACCESS_KEY_ID $CREDFILE | cut -f 2 -d"=" | tr -d ' ')
+      AWS_SECRET_ACCESS_KEY=$(grep -m 1 -i AWS_SECRET_ACCESS_KEY $CREDFILE | cut -f 2 -d"=" | tr -d ' ')
+    fi
+    # todo: if the key is found in the creds file, then if we can assume it'll be there in the future,
+    # then there's likely no point saving it in the account config, so we should do what needs to be done
+    # to disable saving the AWS creds in the acme.sh config.
+  fi
+
   if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     AWS_ACCESS_KEY_ID=""
     AWS_SECRET_ACCESS_KEY=""

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -31,9 +31,9 @@ dns_aws_add() {
   # it does not honour [sections] in the ini formatted credentials file.
   if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     CREDFILE="${HOME}/.aws/credentials"
-    if [ -e $CREDFILE ]; then
-      AWS_ACCESS_KEY_ID=$(grep -m 1 -i AWS_ACCESS_KEY_ID $CREDFILE | cut -f 2 -d"=" | tr -d ' ')
-      AWS_SECRET_ACCESS_KEY=$(grep -m 1 -i AWS_SECRET_ACCESS_KEY $CREDFILE | cut -f 2 -d"=" | tr -d ' ')
+    if [ -e ${CREDFILE} ]; then
+      AWS_ACCESS_KEY_ID=$(grep -m 1 -i AWS_ACCESS_KEY_ID ${CREDFILE} | cut -f 2 -d"=" | tr -d ' ')
+      AWS_SECRET_ACCESS_KEY=$(grep -m 1 -i AWS_SECRET_ACCESS_KEY ${CREDFILE} | cut -f 2 -d"=" | tr -d ' ')
     fi
     # todo: if the key is found in the creds file, then if we can assume it'll be there in the future,
     # then there's likely no point saving it in the account config, so we should do what needs to be done


### PR DESCRIPTION
Adds code to attempt to get AWS creds from ~/.aws/credentials, if the file exists, and the creds aren't already set. This credentials file is used/created by the AWS CLI tools, so may already exist on many of the hosts that also run dns_aws.sh - if it does, it saves users from having to edit dns_aws.sh.
It's pretty simplistic, it just grabs the first values from the file, it does not honour [sections] in the ini formatted credentials file.

Second attempt, after jenkins complained about my slackness with variable quoting.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->