### PR TITLE
dns_azure : Multiple domains with same ending bug

### DIFF
--- a/dnsapi/dns_azure.sh
+++ b/dnsapi/dns_azure.sh
@@ -317,7 +317,7 @@ _get_root() {
   ## Per https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#dns-limits you are limited to 100 Zone/subscriptions anyways
   ##
   _azure_rest GET "https://management.azure.com/subscriptions/$subscriptionId/providers/Microsoft.Network/dnszones?\$top=500&api-version=2017-09-01" "" "$accesstoken"
-  # Find matching domain name is Json response
+  # Find matching domain name in Json response
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)
     _debug2 "Checking domain: $h"
@@ -328,7 +328,7 @@ _get_root() {
     fi
 
     if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
-      _domain_id=$(echo "$response" | _egrep_o "\\{\"id\":\"[^\"]*$h\"" | head -n 1 | cut -d : -f 2 | tr -d \")
+      _domain_id=$(echo "$response" | _egrep_o "\\{\"id\":\"[^\"]*\\/$h\"" | head -n 1 | cut -d : -f 2 | tr -d \")
       if [ "$_domain_id" ]; then
         if [ "$i" = 1 ]; then
           #create the record at the domain apex (@) if only the domain name was provided as --domain-alias


### PR DESCRIPTION
We have a few domains that ends the same. For example :
  iperfony.com
  perfony.com

The problem was in the _get_root functions, when getting the domain_id :
only the first result "iperfony.com" was returned, because "perfony.com"
is contained in the "iperfony.com" string.

The correction consist of being strict in the regex, adding a slash (/)
so that it will only match on ".*/(perfony.com).*" and not
".*(perfony.com).*".

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->