### PR TITLE
Work around bug in _egrep_o() function

### DIFF
--- a/dnsapi/dns_freedns.sh
+++ b/dnsapi/dns_freedns.sh
@@ -305,7 +305,7 @@ _freedns_domain_id() {
 
     domain_id="$(echo "$htmlpage" | tr -d "[:space:]" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td>$search_domain</td>\|<td>$search_domain(.*)</td>" \
-      | _egrep_o "edit\.php\?edit_domain_id=[0-9a-zA-Z]+" \
+      | _egrep_o "edit\.php?edit_domain_id=[0-9a-zA-Z]*" \
       | cut -d = -f 2)"
     # The above beauty extracts domain ID from the html page...
     # strip out all blank space and new lines. Then insert newlines
@@ -352,7 +352,7 @@ _freedns_data_id() {
     data_id="$(echo "$htmlpage" | tr -d "[:space:]" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td[a-zA-Z=#]*>$record_type</td>" \
       | grep "<ahref.*>$search_domain</a>" \
-      | _egrep_o "edit\.php\?data_id=[0-9a-zA-Z]+" \
+      | _egrep_o "edit\.php?data_id=[0-9a-zA-Z]*" \
       | cut -d = -f 2)"
     # The above beauty extracts data ID from the html page...
     # strip out all blank space and new lines. Then insert newlines

--- a/dnsapi/dns_freedns.sh
+++ b/dnsapi/dns_freedns.sh
@@ -305,7 +305,7 @@ _freedns_domain_id() {
 
     domain_id="$(echo "$htmlpage" | tr -d "[:space:]" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td>$search_domain</td>\|<td>$search_domain(.*)</td>" \
-      | grep -o "edit\.php?edit_domain_id=[0-9a-zA-Z]*" \
+      | sed -n 's/.*\(edit\.php?edit_domain_id=[0-9a-zA-Z]*\).*/\1/p' \
       | cut -d = -f 2)"
     # The above beauty extracts domain ID from the html page...
     # strip out all blank space and new lines. Then insert newlines
@@ -352,7 +352,7 @@ _freedns_data_id() {
     data_id="$(echo "$htmlpage" | tr -d "[:space:]" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td[a-zA-Z=#]*>$record_type</td>" \
       | grep "<ahref.*>$search_domain</a>" \
-      | grep -o "edit\.php?data_id=[0-9a-zA-Z]*" \
+      | sed -n 's/.*\(edit\.php?data_id=[0-9a-zA-Z]*\).*/\1/p' \
       | cut -d = -f 2)"
     # The above beauty extracts data ID from the html page...
     # strip out all blank space and new lines. Then insert newlines

--- a/dnsapi/dns_freedns.sh
+++ b/dnsapi/dns_freedns.sh
@@ -305,7 +305,7 @@ _freedns_domain_id() {
 
     domain_id="$(echo "$htmlpage" | tr -d "[:space:]" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td>$search_domain</td>\|<td>$search_domain(.*)</td>" \
-      | _egrep_o "edit\.php?edit_domain_id=[0-9a-zA-Z]*" \
+      | grep -o "edit\.php?edit_domain_id=[0-9a-zA-Z]*" \
       | cut -d = -f 2)"
     # The above beauty extracts domain ID from the html page...
     # strip out all blank space and new lines. Then insert newlines
@@ -352,7 +352,7 @@ _freedns_data_id() {
     data_id="$(echo "$htmlpage" | tr -d "[:space:]" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td[a-zA-Z=#]*>$record_type</td>" \
       | grep "<ahref.*>$search_domain</a>" \
-      | _egrep_o "edit\.php?data_id=[0-9a-zA-Z]*" \
+      | grep -o "edit\.php?data_id=[0-9a-zA-Z]*" \
       | cut -d = -f 2)"
     # The above beauty extracts data ID from the html page...
     # strip out all blank space and new lines. Then insert newlines


### PR DESCRIPTION
_egrep_o() function accepts extended regex and on systems that do not have egrep uses sed to emulate egrep. This is failing on the specific regex I was using before my last commit... The problem is that I fixed it by passing in non-extended regex which then fails on systems that do have egrep. So I am no longer using _egrep_o.
See bugs #2385 and #2414 
Note... even if those bugs are fixed, I would like to merge this PR and stop using _egrep_o()
Thanks