### PR TITLE
 Linode APIv4 DNS plugin set minimum TTL

### DIFF
--- a/dnsapi/dns_linode_v4.sh
+++ b/dnsapi/dns_linode_v4.sh
@@ -31,7 +31,8 @@ dns_linode_v4_add() {
   _payload="{
               \"type\": \"TXT\",
               \"name\": \"$_sub_domain\",
-              \"target\": \"$txtvalue\"
+              \"target\": \"$txtvalue\",
+              \"ttl_sec\": 300
             }"
 
   if _rest POST "/$_domain_id/records" "$_payload" && [ -n "$response" ]; then


### PR DESCRIPTION
The default Linode TTL is 86400 seconds per https://www.linode.com/docs/platform/manager/dns-manager/ and my dns-01 issuance testing was failing as a result of that. I altered the payload to configure a TTL of 5 minutes and my dns-01 testing began working.

Here's an example of the script I am using on a Synology NAS.
```
export CERT_FOLDER="$(find /usr/syno/etc/certificate/_archive/ -maxdepth 1 -mindepth 1 -type d)"
export CERT_DOMAIN="whatever.example.notatld"
export LINODE_V4_API_KEY="abcdefg123456"

/usr/local/share/acme.sh/acme.sh  --issue -d "$CERT_DOMAIN" --dns "dns_linode_v4" \
    --cert-file "$CERT_FOLDER/cert.pem" \
    --key-file "$CERT_FOLDER/privkey.pem" \
    --fullchain-file "$CERT_FOLDER/fullchain.pem" \
    --capath "$CERT_FOLDER/chain.pem" \
    --reloadcmd "/usr/syno/sbin/synoservicectl --reload nginx" \
    --dnssleep 360 \
    --staging \
    --force
```