### PR TITLE
fix grep error when txt value begin with - char

### DIFF
--- a/dnsapi/dns_ali.sh
+++ b/dnsapi/dns_ali.sh
@@ -185,7 +185,7 @@ _clean() {
     return 1
   fi
 
-  record_id="$(echo "$response" | tr '{' "\n" | grep "$_sub_domain" | grep "$txtvalue" | tr "," "\n" | grep RecordId | cut -d '"' -f 4)"
+  record_id="$(echo "$response" | tr '{' "\n" | grep "$_sub_domain" | grep -- "$txtvalue" | tr "," "\n" | grep RecordId | cut -d '"' -f 4)"
   _debug2 record_id "$record_id"
 
   if [ -z "$record_id" ]; then


### PR DESCRIPTION
first, Thanks for contributing !

某些情况下 _acme-challenge 生成的 TXT 记录开头可能是 -，比如：

/*** from 阿里云解析 DNS 操作日志 *** /
新增解析记录TXT记录 _acme-challenge 默认 -ydqkDpgiJzHXQQV43h1-HpZ6-S3WAyuHxZ6lgLIm3A ( TTL: 600)
/*** end of from 阿里云解析 DNS 操作日志 *** /

此时grep 匹配时会以为是命令选项而产生错误，busybox版的grep错误提示如下：

grep: invalid option -- 'y'
BusyBox v1.22.1 (2018-09-28 14:18:44 CST) multi-call binary.