### PR TITLE
README.md update - acme.sh needs root/sudoer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 - Simplest shell script for Let's Encrypt free certificate client.
 - Purely written in Shell with no dependencies on python or the official Let's Encrypt client.
 - Just one script to issue, renew and install your certificates automatically.
-- DOES NOT require `root/sudoer` access.
 - Docker friendly
 - IPv6 support
 - Cron job notifications for renewal or error etc.
@@ -184,6 +183,8 @@ More examples: https://github.com/Neilpang/acme.sh/wiki/How-to-issue-a-cert
 
 
 # 3. Install the cert to Apache/Nginx etc.
+
+**(requires you to be root/sudoer, since it is required to interact with your HTTP server or service manager)**
 
 After the cert is generated, you probably want to install/copy the cert to your Apache/Nginx or other servers.
 You **MUST** use this command to copy the certs to the target files, **DO NOT** use the certs files in **~/.acme.sh/** folder, they are for internal use only, the folder structure may change in the future.


### PR DESCRIPTION
Changes reflect the fact that in order to have a fully functional acme.sh script that renews certificates automatically, you must run the `--install-cert` command as root or at least add your `--reloadcmd` command to your /etc/sudoers (or /etc/doas or whatever). I think this was a needed clarification in Readme.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->