### PR TITLE
Add to curl the `--head` option for newNonce

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1878,7 +1878,7 @@ _send_signed_request() {
       if [ "$ACME_NEW_NONCE" ]; then
         _debug2 "Get nonce with HEAD. ACME_NEW_NONCE" "$ACME_NEW_NONCE"
         nonceurl="$ACME_NEW_NONCE"
-        if _post "" "$nonceurl" "" "HEAD" "$__request_conent_type"; then
+        if _post "" "$nonceurl" "" "HEAD --head" "$__request_conent_type"; then
           _headers="$(cat "$HTTP_HEADER")"
           _debug2 _headers "$_headers"
           _CACHED_NONCE="$(echo "$_headers" | grep -i "Replay-Nonce:" | _head_n 1 | tr -d "\r\n " | cut -d ':' -f 2)"


### PR DESCRIPTION
Retrieving headers for `/acme/new-nonce` with curl(1) can result in long delays or hanging when curl is using HTTP/1.1. This affects CentOS 7.x clients, for which HTTP/2 support isn't available in the version of curl provided.

This change sets the explicit `--head` option for curl requests which use the `HEAD` command in the new-nonce request.

Embedded comments in curl source states:

```On HTTP 1.1, when connection is not to get closed, but no
Content-Length nor Content-Encoding chunked have been
received, according to RFC2616 section 4.4 point 5, we
assume that the server will close the connection to
signal the end of the document.
```
From the curl manpage, pertainig to setting the custom request method:

```
This option only changes the actual word used in the HTTP request, it
does not alter the way curl behaves. So for example if you want to
make a proper HEAD request, using -X HEAD will not  suffice.
You need to use the -I, --head option.
```
 

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->