### PR TITLE
Use more widely supported options for the "tr" command line utility b…y removing the use of the character class representation option. [:space:] => "\t\r\n\v\f"

### DIFF
--- a/dnsapi/dns_freedns.sh
+++ b/dnsapi/dns_freedns.sh
@@ -303,7 +303,7 @@ _freedns_domain_id() {
       return 1
     fi
 
-    domain_id="$(echo "$htmlpage" | tr -d "\r\n" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
+    domain_id="$(echo "$htmlpage" | tr -d "\t\r\n\v\f" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td>$search_domain</td>\|<td>$search_domain(.*)</td>" \
       | sed -n 's/.*\(edit\.php?edit_domain_id=[0-9a-zA-Z]*\).*/\1/p' \
       | cut -d = -f 2)"
@@ -349,7 +349,7 @@ _freedns_data_id() {
       return 1
     fi
 
-    data_id="$(echo "$htmlpage" | tr -d "\r\n" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
+    data_id="$(echo "$htmlpage" | tr -d "\t\r\n\v\f" | sed 's/<tr>/@<tr>/g' | tr '@' '\n' \
       | grep "<td[a-zA-Z=#]*>$record_type</td>" \
       | grep "<ahref.*>$search_domain</a>" \
       | sed -n 's/.*\(edit\.php?data_id=[0-9a-zA-Z]*\).*/\1/p' \


### PR DESCRIPTION
Reference comment: https://github.com/Neilpang/acme.sh/issues/2305#issuecomment-545472789

Update to change: https://github.com/Neilpang/acme.sh/pull/2537

### Original problem:
Add support for Synology routers while using [dnsapi/dns_freedns.sh](https://github.com/Neilpang/acme.sh/blob/master/dnsapi/dns_freedns.sh). Synology router scripting stacks do not have a version of the "tr" command line utility that supports character class representation option i.e. the "[:space:]" :

`tr -d "[:space:]"` should be replaced with `tr -d "\t\r\n\v\f"` inside of [dnsapi/dns_freedns.sh](https://github.com/Neilpang/acme.sh/blob/master/dnsapi/dns_freedns.sh) for better support across embedded linux systems and routers.