### PR TITLE
Fix issuing certs

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1948,7 +1948,7 @@ _send_signed_request() {
       if [ "$url" = "$ACME_NEW_ACCOUNT" ] || [ "$url" = "$ACME_REVOKE_CERT" ]; then
         protected="$JWK_HEADERPLACE_PART1$nonce\", \"url\": \"${url}$JWK_HEADERPLACE_PART2, \"jwk\": $jwk"'}'
       else
-        protected="$JWK_HEADERPLACE_PART1$nonce\", \"url\": \"${url}$JWK_HEADERPLACE_PART2, \"kid\": \"${ACCOUNT_URL}\""'}'
+        protected="$JWK_HEADERPLACE_PART1$nonce\", \"url\": \"${url}$JWK_HEADERPLACE_PART2, \"kid\": \""$(echo "${ACCOUNT_URL}" | sed -e "s/location\\://")"\""'}'
       fi
     else
       protected="$JWK_HEADERPLACE_PART1$nonce\", \"url\": \"${url}$JWK_HEADERPLACE_PART2, \"jwk\": $jwk"'}'
@@ -3982,7 +3982,7 @@ issue() {
       #for dns manual mode
       _savedomainconf "Le_OrderFinalize" "$Le_OrderFinalize"
 
-      _authorizations_seg="$(echo "$response" | _egrep_o '"authorizations" *: *\[[^\]*\]' | cut -d '[' -f 2 | tr -d ']' | tr -d '"')"
+      _authorizations_seg="$(echo "$response" | tr '\n' ' ' | _egrep_o '"authorizations" *: *\[[^\]*\]' | cut -d '[' -f 2 | tr -d ']' | tr -d '"')"
       _debug2 _authorizations_seg "$_authorizations_seg"
       if [ -z "$_authorizations_seg" ]; then
         _err "_authorizations_seg not found."
@@ -4480,7 +4480,7 @@ $_authorizations_map"
     _link_cert_retry=0
     _MAX_CERT_RETRY=5
     while [ "$_link_cert_retry" -lt "$_MAX_CERT_RETRY" ]; do
-      if _contains "$response" "\"status\":\"valid\""; then
+      if _contains "$response" "\"status\":\"valid\"" || _contains "$response" "\"status\": \"valid\""; then
         _debug "Order status is valid."
         Le_LinkCert="$(echo "$response" | _egrep_o '"certificate" *: *"[^"]*"' | cut -d '"' -f 4)"
         _debug Le_LinkCert "$Le_LinkCert"


### PR DESCRIPTION
I encountered a few problems after updating to new newest acme.sh. (platform: Fedora 24)

First, I was getting "KeyID header contained an invalid account URL", because the "location:" wasn't getting stripped out of the KeyID header.
Next, I got an error where it didn't want to recognize the "authorizations" part of the JSON response. I fixed this by stripping newlines before searching for it.
Finally, it wasn't recognizing the "valid" status because there was a space after the colon (`"status": "valid"` instead of `"status":"valid"`).

I've tried to only use features that are used elsewhere in acme.sh to maintain compatibility with dash and sh, but I haven't tested with anything other than bash.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->