### PR TITLE
Avoid API throttling errors in AWS DNS plugin

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -6,6 +6,8 @@
 #AWS_SECRET_ACCESS_KEY="xxxxxxx"
 
 #This is the Amazon Route53 api wrapper for acme.sh
+#All `sleep` commands are included to avoid Route53 throttling, see
+#https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests
 
 AWS_HOST="route53.amazonaws.com"
 AWS_URL="https://$AWS_HOST"
@@ -43,6 +45,7 @@ dns_aws_add() {
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
     _err "invalid domain"
+    sleep 1
     return 1
   fi
   _debug _domain_id "$_domain_id"
@@ -51,6 +54,7 @@ dns_aws_add() {
 
   _info "Getting existing records for $fulldomain"
   if ! aws_rest GET "2013-04-01$_domain_id/rrset" "name=$fulldomain&type=TXT"; then
+    sleep 1
     return 1
   fi
 
@@ -63,6 +67,7 @@ dns_aws_add() {
 
   if [ "$_resource_record" ] && _contains "$response" "$txtvalue"; then
     _info "The TXT record already exists. Skipping."
+    sleep 1
     return 0
   fi
 
@@ -72,9 +77,10 @@ dns_aws_add() {
 
   if aws_rest POST "2013-04-01$_domain_id/rrset/" "" "$_aws_tmpl_xml" && _contains "$response" "ChangeResourceRecordSetsResponse"; then
     _info "TXT record updated successfully."
+    sleep 1
     return 0
   fi
-
+  sleep 1
   return 1
 }
 
@@ -93,6 +99,7 @@ dns_aws_rm() {
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
     _err "invalid domain"
+    sleep 1
     return 1
   fi
   _debug _domain_id "$_domain_id"
@@ -101,6 +108,7 @@ dns_aws_rm() {
 
   _info "Getting existing records for $fulldomain"
   if ! aws_rest GET "2013-04-01$_domain_id/rrset" "name=$fulldomain&type=TXT"; then
+    sleep 1
     return 1
   fi
 
@@ -109,6 +117,7 @@ dns_aws_rm() {
     _debug "_resource_record" "$_resource_record"
   else
     _debug "no records exist, skip"
+    sleep 1
     return 0
   fi
 
@@ -116,9 +125,10 @@ dns_aws_rm() {
 
   if aws_rest POST "2013-04-01$_domain_id/rrset/" "" "$_aws_tmpl_xml" && _contains "$response" "ChangeResourceRecordSetsResponse"; then
     _info "TXT record deleted successfully."
+    sleep 1
     return 0
   fi
-
+  sleep 1
   return 1
 
 }

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -6,7 +6,7 @@
 #AWS_SECRET_ACCESS_KEY="xxxxxxx"
 
 #This is the Amazon Route53 api wrapper for acme.sh
-#All `sleep` commands are included to avoid Route53 throttling, see
+#All `_sleep` commands are included to avoid Route53 throttling, see
 #https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests
 
 AWS_HOST="route53.amazonaws.com"
@@ -45,7 +45,7 @@ dns_aws_add() {
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
     _err "invalid domain"
-    sleep 1
+    _sleep 1
     return 1
   fi
   _debug _domain_id "$_domain_id"
@@ -54,7 +54,7 @@ dns_aws_add() {
 
   _info "Getting existing records for $fulldomain"
   if ! aws_rest GET "2013-04-01$_domain_id/rrset" "name=$fulldomain&type=TXT"; then
-    sleep 1
+    _sleep 1
     return 1
   fi
 
@@ -67,7 +67,7 @@ dns_aws_add() {
 
   if [ "$_resource_record" ] && _contains "$response" "$txtvalue"; then
     _info "The TXT record already exists. Skipping."
-    sleep 1
+    _sleep 1
     return 0
   fi
 
@@ -77,10 +77,10 @@ dns_aws_add() {
 
   if aws_rest POST "2013-04-01$_domain_id/rrset/" "" "$_aws_tmpl_xml" && _contains "$response" "ChangeResourceRecordSetsResponse"; then
     _info "TXT record updated successfully."
-    sleep 1
+    _sleep 1
     return 0
   fi
-  sleep 1
+  _sleep 1
   return 1
 }
 
@@ -99,7 +99,7 @@ dns_aws_rm() {
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
     _err "invalid domain"
-    sleep 1
+    _sleep 1
     return 1
   fi
   _debug _domain_id "$_domain_id"
@@ -108,7 +108,7 @@ dns_aws_rm() {
 
   _info "Getting existing records for $fulldomain"
   if ! aws_rest GET "2013-04-01$_domain_id/rrset" "name=$fulldomain&type=TXT"; then
-    sleep 1
+    _sleep 1
     return 1
   fi
 
@@ -117,7 +117,7 @@ dns_aws_rm() {
     _debug "_resource_record" "$_resource_record"
   else
     _debug "no records exist, skip"
-    sleep 1
+    _sleep 1
     return 0
   fi
 
@@ -125,10 +125,10 @@ dns_aws_rm() {
 
   if aws_rest POST "2013-04-01$_domain_id/rrset/" "" "$_aws_tmpl_xml" && _contains "$response" "ChangeResourceRecordSetsResponse"; then
     _info "TXT record deleted successfully."
-    sleep 1
+    _sleep 1
     return 0
   fi
-  sleep 1
+  _sleep 1
   return 1
 
 }


### PR DESCRIPTION
The AWS DNS (Route53) API currently has a rate limit of 5 requests per second. Requests in excess of this rate return "Throttling/Rate exceeded" errors. This issue has been reported a number of times, see:
https://github.com/Neilpang/acme.sh/issues/1506
https://github.com/Neilpang/acme.sh/issues/2132
https://github.com/Neilpang/acme.sh/issues/2382

This pull request addresses the issue by adding one-second pauses in the form of `sleep 1`. 

Adding a DNS entry to Route53 without error requires four API requests. Removing a DNS entry without error also requires four API requests. When this code is merged, there will be a one-second pause after the fourth API request. Whether or not there are errors, this PR adds two seconds per domain to issue/renewal.

Reference:
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests