### PR TITLE
Add openssh package for ssh.sh deploy support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10
 RUN apk update -f \
   && apk --no-cache add -f \
   openssl \
-  openssh \
+  openssh-client \
   coreutils \
   bind-tools \
   curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.10
 RUN apk update -f \
   && apk --no-cache add -f \
   openssl \
+  openssh \
   coreutils \
   bind-tools \
   curl \


### PR DESCRIPTION
* `acme.sh`'s `ssh.sh` is probably one of the deploy hooks that's most versatile
* By default, it's not installed on `alpine` docker images and therefore is lacking in the `acme.sh` docker image
* This change adds the `openssh-client` package and therefore the `ssh` and associated commands

BTW: `acme.sh` is awesome. 🥇 
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->