### PR TITLE
debug_bash_helper: Use eval as busybox systems have problems

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -268,31 +268,31 @@ _usage() {
 __debug_bash_helper() {
   # At this point only do for --debug 3
   if [ "${DEBUG:-$DEBUG_LEVEL_NONE}" -lt "$DEBUG_LEVEL_3" ]; then
-    echo ""
     return
   fi
   # Return extra debug info when running with bash, otherwise return empty
   # string.
   if [ -z "${BASH_VERSION}" ]; then
-    echo ""
     return
   fi
   # We are a bash shell at this point, return the filename, function name, and
   # line number as a string
   _dbh_saveIFS=$IFS
   IFS=" "
-  # Must use eval or syntax error happens under dash
+  # Must use eval or syntax error happens under dash. The eval should use
+  # single quotes as older versions of busybox had a bug with double quotes and
+  # eval.
   # Use 'caller 1' as we want one level up the stack as we should be called
   # by one of the _debug* functions
-  eval "_dbh_called=($(caller 1))"
+  eval '_dbh_called=($(caller 1))'
   IFS=$_dbh_saveIFS
-  _dbh_file=${_dbh_called[2]}
+  eval '_dbh_file=${_dbh_called[2]}'
   if [ -n "${_script_home}" ]; then
     # Trim off the _script_home directory name
-    _dbh_file=${_dbh_file#$_script_home/}
+    eval '_dbh_file=${_dbh_file#$_script_home/}'
   fi
-  _dbh_function=${_dbh_called[1]}
-  _dbh_lineno=${_dbh_called[0]}
+  eval '_dbh_function=${_dbh_called[1]}'
+  eval '_dbh_lineno=${_dbh_called[0]}'
   printf "%-40s " "$_dbh_file:${_dbh_function}:${_dbh_lineno}"
 }
 


### PR DESCRIPTION
In _debug_bash_helper use eval as we are seeing issues with busybox
systems having issues with array access. Even though they aren't
actually running the code they appear to be parsing it and failing.

Resolves: #2579

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->