### PR TITLE
zone.eu dns api: use different method to get root

### DIFF
--- a/dnsapi/dns_zone.sh
+++ b/dnsapi/dns_zone.sh
@@ -136,10 +136,10 @@ _get_root() {
     if [ -z "$h" ]; then
       return 1
     fi
-    if ! _zone_rest GET "dns/$h/a"; then
+    if ! _zone_rest GET "dns/$h"; then
       return 1
     fi
-    if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
+    if _contains "$response" "\"identificator\":\"$h\"" >/dev/null; then
       _domain=$h
       return 0
     fi


### PR DESCRIPTION
use more robust check to find out dns root, no A record check anymore.

Issue came to light in https://github.com/Neilpang/acme.sh/issues/2146