### PR TITLE
dns_lexicon.sh: Add extra variable _API_KEY

### DIFF
--- a/dnsapi/dns_lexicon.sh
+++ b/dnsapi/dns_lexicon.sh
@@ -63,6 +63,16 @@ _lexicon_init() {
     _saveaccountconf_mutable "$Lx_domaintoken" "$Lx_domaintoken_v"
     eval export "$Lx_domaintoken"
   fi
+
+  # shellcheck disable=SC2018,SC2019
+  Lx_api_key=$(echo LEXICON_"${PROVIDER}"_API_KEY | tr 'a-z' 'A-Z')
+  eval "$Lx_api_key=\${$Lx_api_key:-$(_readaccountconf_mutable "$Lx_api_key")}"
+  Lx_api_key_v=$(eval echo \$"$Lx_api_key")
+  _secure_debug "$Lx_api_key" "$Lx_api_key_v"
+  if [ "$Lx_api_key_v" ]; then
+    _saveaccountconf_mutable "$Lx_api_key" "$Lx_api_key_v"
+    eval export "$Lx_api_key"
+  fi
 }
 
 ########  Public functions #####################


### PR DESCRIPTION
Lexicon TransIP module uses LEXICON_TRANSIP_API_KEY for authentication.
(https://github.com/AnalogJ/lexicon/blob/master/lexicon/providers/transip.py)

A simple search reveals more modules that uses LEXICON_${PROVIDER}_API_KEY variable.
(https://github.com/AnalogJ/lexicon/search?q=--auth-api-key&unscoped_q=--auth-api-key)