### PR TITLE
fix: added public dns zones filter

### DIFF
--- a/dnsapi/dns_gcloud.sh
+++ b/dnsapi/dns_gcloud.sh
@@ -131,7 +131,7 @@ _dns_gcloud_find_zone() {
     filter="$filter$part. "
     part="$(echo "$part" | sed 's/[^.]*\.*//')"
   done
-  filter="$filter)"
+  filter="$filter) AND visibility=public"
   _debug filter "$filter"
 
   # List domains and find the zone with the deepest sub-domain (in case of some levels of delegation)


### PR DESCRIPTION
GCloud can have private DNS zones which are inaccessible to ACME (and can't be used for validation). This fix adds a filter to use public zones only.